### PR TITLE
Keep focus while adding items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Manage and apply templates to lists ([#255](https://github.com/garritfra/fling/pull/255))
+- Keep text field active after adding a new item ([#256](https://github.com/garritfra/fling/pull/256))
 
 ## v0.8.5 (2024-07-16)
 

--- a/lib/pages/list.dart
+++ b/lib/pages/list.dart
@@ -24,6 +24,7 @@ class ListPage extends StatefulWidget {
 
 class _ListPageState extends State<ListPage> {
   final newItemController = TextEditingController();
+  final newItemFocusNode = FocusNode();
 
   @override
   void dispose() {
@@ -94,9 +95,11 @@ class _ListPageState extends State<ListPage> {
         // TODO: use subscribed model in state
         child: TextField(
             controller: newItemController,
+            focusNode: newItemFocusNode,
             onSubmitted: (value) {
               list.addItem(value);
               newItemController.clear();
+              newItemFocusNode.requestFocus();
             },
             decoration: InputDecoration(
               hintText: l10n.item_hint,
@@ -108,6 +111,7 @@ class _ListPageState extends State<ListPage> {
 
     Widget buildListItem(ListItem item) {
       var textController = TextEditingController(text: item.text);
+
       return Card(
         child: ListTile(
           onTap: () => showDialog(

--- a/lib/pages/template.dart
+++ b/lib/pages/template.dart
@@ -22,6 +22,7 @@ class TemplatePage extends StatefulWidget {
 
 class _TemplatePageState extends State<TemplatePage> {
   final newItemController = TextEditingController();
+  final newItemFocusNode = FocusNode();
 
   @override
   void dispose() {
@@ -45,9 +46,11 @@ class _TemplatePageState extends State<TemplatePage> {
         // TODO: use subscribed model in state
         child: TextField(
             controller: newItemController,
+            focusNode: newItemFocusNode,
             onSubmitted: (value) {
               template.addItem(value);
               newItemController.clear();
+              newItemFocusNode.requestFocus();
             },
             decoration: InputDecoration(
               hintText: l10n.item_hint,


### PR DESCRIPTION
### Description

Keep focus active while adding items.

### Changes proposed in this pull request

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request ensures that the input field remains focused after adding a new item in both ListPage and TemplatePage, improving the user experience by allowing continuous item addition without manually refocusing the input field.

- **New Features**:
    - Maintained focus on the input field after adding a new item in both ListPage and TemplatePage.

<!-- Generated by sourcery-ai[bot]: end summary -->