### PR TITLE
Keep keyboard visible when returning to app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Tab layout for lists: lists now appear as horizontally scrollable tabs, replacing the separate list overview/detail navigation ([#511](https://github.com/garritfra/fling/pull/511))
 
+### Fixed
+
+- Keep keyboard visible when returning to app from background ([#510](https://github.com/garritfra/fling/pull/510))
+
 ## v0.10.2 (2025-10-31)
 
 ### Fixed

--- a/lib/pages/list.dart
+++ b/lib/pages/list.dart
@@ -22,15 +22,28 @@ class ListPage extends StatefulWidget {
   State<ListPage> createState() => _ListPageState();
 }
 
-class _ListPageState extends State<ListPage> {
+class _ListPageState extends State<ListPage> with WidgetsBindingObserver {
   final newItemController = TextEditingController();
   final newItemFocusNode = FocusNode();
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && newItemFocusNode.hasFocus) {
+      newItemFocusNode.requestFocus();
+    }
+  }
+
+  @override
   void dispose() {
-    // Clean up the controller when the widget is removed from the
-    // widget tree.
+    WidgetsBinding.instance.removeObserver(this);
     newItemController.dispose();
+    newItemFocusNode.dispose();
     super.dispose();
   }
 

--- a/lib/pages/template.dart
+++ b/lib/pages/template.dart
@@ -20,15 +20,28 @@ class TemplatePage extends StatefulWidget {
   State<TemplatePage> createState() => _TemplatePageState();
 }
 
-class _TemplatePageState extends State<TemplatePage> {
+class _TemplatePageState extends State<TemplatePage> with WidgetsBindingObserver {
   final newItemController = TextEditingController();
   final newItemFocusNode = FocusNode();
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && newItemFocusNode.hasFocus) {
+      newItemFocusNode.requestFocus();
+    }
+  }
+
+  @override
   void dispose() {
-    // Clean up the controller when the widget is removed from the
-    // widget tree.
+    WidgetsBinding.instance.removeObserver(this);
     newItemController.dispose();
+    newItemFocusNode.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
Fixes #451

### Description

When the user had the text input focused on the list or template page and switched to another app, the OS would dismiss the keyboard. Upon returning, the keyboard would not reappear even though the input still had logical focus.

### Changes proposed in this pull request

- Added `WidgetsBindingObserver` to `_ListPageState` and `_TemplatePageState`
- Re-requests focus on the input field when the app lifecycle state resumes and the field previously had focus
- Properly disposes the `FocusNode` in both pages

### ToDo

- [ ] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
- [ ] The "Unreleased" section in the changelog has been updated, if applicable

## Summary by Sourcery

Ensure text input fields on list and template pages correctly restore keyboard visibility when returning to the app from background.

Bug Fixes:
- Restore keyboard visibility for focused inputs on the list and template pages when the app resumes from the background.
- Prevent potential resource leaks by disposing focus nodes on the list and template pages.