### PR TITLE
Phase 1 Slice 1 — GET /v1/me end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,19 @@ jobs:
       - run: npm ci --no-audit
       - run: npm run lint
       - run: npx tsc --noEmit
-      - run: npx vitest run --exclude 'test/rules/**' --exclude 'test/api/**'
+      - run: |
+          npx vitest run \
+            --exclude 'test/rules/**' \
+            --exclude 'test/api/**' \
+            --exclude 'test/features/**' \
+            --exclude 'test/core/middleware/auth.test.ts' \
+            --exclude 'test/core/middleware/idempotency.test.ts'
       - name: Install firebase-tools
         run: npm install -g firebase-tools@^13.29.0
-      - name: Run emulator-backed tests (rules + api)
+      - name: Run emulator-backed tests (rules + api + features + auth middleware)
         run: |
           firebase emulators:exec --only firestore,auth --project fling-rules-test \
-            "npx vitest run test/rules test/api"
+            "npx vitest run test/rules test/api test/features test/core/middleware/auth.test.ts"
 
   flutter:
     name: flutter (analyze + test + boundaries)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,12 @@ jobs:
       - run: npm ci --no-audit
       - run: npm run lint
       - run: npx tsc --noEmit
-      - run: |
-          npx vitest run \
-            --exclude 'test/rules/**' \
-            --exclude 'test/api/**' \
-            --exclude 'test/features/**' \
-            --exclude 'test/core/middleware/auth.test.ts' \
-            --exclude 'test/core/middleware/idempotency.test.ts'
       - name: Install firebase-tools
         run: npm install -g firebase-tools@^13.29.0
-      - name: Run emulator-backed tests (rules + api + features + auth middleware)
+      - name: Run all tests (emulator required for integration tests)
         run: |
           firebase emulators:exec --only firestore,auth --project fling-rules-test \
-            "npx vitest run test/rules test/api test/features test/core/middleware/auth.test.ts"
+            "npx vitest run"
 
   flutter:
     name: flutter (analyze + test + boundaries)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,179 @@
+# Contributing to Fling
+
+## Prerequisites
+
+| Tool | Install |
+|------|---------|
+| Flutter 3.35+ | https://flutter.dev/docs/get-started/install |
+| Node 20 | `brew install node` or via [asdf](https://asdf-vm.com/) / [mise](https://mise.jdx.dev/) (`.tool-versions` is committed) |
+| Firebase CLI | `npm i -g firebase-tools` then `firebase login` |
+| Java 11+ | Required for the OpenAPI → Dart client generator. `brew install openjdk@21` |
+| jq | `brew install jq` — used in test scripts |
+
+---
+
+## Running locally
+
+### 1. Install dependencies
+
+```bash
+# Backend
+npm ci --no-audit --prefix functions
+
+# Flutter
+flutter pub get
+```
+
+### 2. Start the Firebase emulators
+
+```bash
+./scripts/dev.sh
+```
+
+This builds the Cloud Functions (`tsc`) and starts the full emulator suite. Emulator state is persisted to `.emulator-data/` between runs so you keep your test data.
+
+| Service | URL |
+|---------|-----|
+| Emulator UI | http://localhost:4000 |
+| Cloud Functions | http://localhost:5001 |
+| Firestore | http://localhost:8080 |
+| Auth | http://localhost:9099 |
+| Hosting (Flutter web) | http://localhost:5050 |
+
+> **Port conflict on 5050?** macOS reserves 5000 for AirPlay Receiver. If 5050 is also taken, start without hosting: `firebase emulators:start --only auth,functions,firestore`
+
+### 3. Run the Flutter app against the emulators
+
+In a second terminal:
+
+```bash
+flutter run -d chrome \
+  --dart-define=FLING_API_BASE_URL=http://localhost:5001/fling-list/us-central1/api
+```
+
+The app will talk to the local emulators for both Firestore realtime reads and the REST API.
+
+---
+
+## Testing the REST API locally
+
+### Get a test token
+
+Sign up via the Auth emulator and grab an ID token in one step:
+
+```bash
+TOKEN=$(curl -s -X POST \
+  "http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"password","returnSecureToken":true}' \
+  | jq -r .idToken)
+echo "Token acquired"
+```
+
+### Hit the API
+
+```bash
+# Health check (no auth required)
+curl -s http://localhost:5001/fling-list/us-central1/api/v1/healthz | jq
+
+# Get your user profile
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:5001/fling-list/us-central1/api/v1/me | jq
+
+# Update display name
+curl -s -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"displayName":"Test User"}' \
+  http://localhost:5001/fling-list/us-central1/api/v1/me | jq
+```
+
+### Browse the OpenAPI docs
+
+The live OpenAPI spec is served by the running emulator:
+
+```
+http://localhost:5001/fling-list/us-central1/api/v1/openapi.json
+```
+
+Paste it into https://editor.swagger.io or any OpenAPI viewer.
+
+---
+
+## Running tests
+
+### Backend (unit + lint)
+
+```bash
+cd functions
+npm run lint       # ESLint
+npm run build      # tsc
+npm test           # Vitest unit tests (no emulator needed)
+```
+
+### Backend (integration + rules tests — needs emulator)
+
+```bash
+# Starts emulator, runs the tests, stops emulator
+firebase emulators:exec --project fling-rules-test --only firestore,auth \
+  "cd functions && npx vitest run test/rules test/api test/features test/core/middleware"
+```
+
+### Flutter
+
+```bash
+flutter analyze    # Dart static analysis
+flutter test       # Unit + widget tests (no emulator needed)
+```
+
+### All at once (mirrors CI)
+
+```bash
+# Backend
+( cd functions && npm run lint && npm run build && npm test )
+
+# Flutter
+flutter analyze && flutter test
+```
+
+---
+
+## Database migrations
+
+Migrations live in `functions/migrations/`. Each file exports a `Migration` object with an `up()` function. The runner tracks applied migrations in `_migrations/{id}` in Firestore.
+
+```bash
+# Run pending migrations against the local emulator
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=fling-list \
+  npm --prefix functions run migrate
+
+# Run against production (requires Firebase login with deploy permissions)
+npm --prefix functions run migrate
+```
+
+---
+
+## Regenerating the Dart API client
+
+The client in `lib/core/api/generated/` is generated from the OpenAPI spec. Regenerate it whenever backend schemas change:
+
+```bash
+./scripts/generate-dart-client.sh
+```
+
+This runs three steps: (1) regenerates `openapi/openapi.json` from the Hono app, (2) runs `openapi-generator-cli` to produce the Dart client, (3) runs `build_runner` for the `built_value` generated code. The output is committed — CI fails if it drifts.
+
+---
+
+## Architecture overview
+
+See [`docs/superpowers/specs/2026-04-24-fling-rewrite-design.md`](docs/superpowers/specs/2026-04-24-fling-rewrite-design.md) for the full design spec.
+
+**Short version:**
+
+- All writes go through the REST API (`functions/src/features/*/routes.ts`). Firestore security rules deny client writes.
+- Reads stream directly from Firestore (realtime collaboration + offline cache).
+- Each feature is a vertical slice under `functions/src/features/<name>/` (backend) and `lib/features/<name>/` (Flutter).
+- The layering rule is `routes → service → repo → Firestore`. Cross-feature interaction uses the events bus (`core/events/`).
+
+**Migration progress:** [`docs/superpowers/migrations/STATUS.md`](docs/superpowers/migrations/STATUS.md)

--- a/docs/superpowers/migrations/STATUS.md
+++ b/docs/superpowers/migrations/STATUS.md
@@ -5,7 +5,7 @@
 > Source of truth for "where are we right now?" in the rewrite.
 
 - **Spec:** [`docs/superpowers/specs/2026-04-24-fling-rewrite-design.md`](../specs/2026-04-24-fling-rewrite-design.md)
-- **Last updated:** 2026-04-26 (Phase 0 complete; deployed to prod, smoke verified)
+- **Last updated:** 2026-04-30 (Phase 1 started; plan published)
 
 ## Status legend
 
@@ -20,7 +20,7 @@
 | Phase | Name | Goal (one line) | Status | Plan | Started | Completed |
 |---|---|---|---|---|---|---|
 | 0 | Foundation | All scaffolding (CI, deps, lint boundaries, empty Hono app, emulator, migrations runner). No user-visible change. | ✅ | [phase-0-foundation.md](./phase-0-foundation.md) | 2026-04-24 | 2026-04-26 |
-| 1 | `me` slice + API foundation | First end-to-end vertical slice. Replaces `setupUser` / `deleteUser`. | ⬜ | _not yet written_ | — | — |
+| 1 | `me` slice + API foundation | First end-to-end vertical slice. Replaces `setupUser` / `deleteUser`. | 🟡 | [phase-1-me-slice.md](./phase-1-me-slice.md) | 2026-04-30 | — |
 | 2 | Households + members + invites | New first-class invite flow. Replaces `cacheJoinHousehold` / `cacheLeaveHousehold` / `inviteToHouseholdByEmail`. | ⬜ | _not yet written_ | — | — |
 | 3 | Lists | All list and item mutations through API. Offline queue + optimistic updates wired up. | ⬜ | _not yet written_ | — | — |
 | 4 | Templates | Same pattern as lists. `:applyTemplate` action live. | ⬜ | _not yet written_ | — | — |
@@ -116,3 +116,4 @@ moves a phase.
 | 2026-04-24 | 0 | Started | — | Phase 0 plan published (`phase-0-foundation.md`) |
 | 2026-04-24 | 0 | Implementation complete | — | Tasks 1–13 landed on branch `phase-0-foundation`; Task 14 (prod deploy + smoke) pending PR merge |
 | 2026-04-26 | 0 | Completed | [#540](https://github.com/garritfra/fling/pull/540) | Deployed via `ci.yml` deploy job; `api` function live at `/v1/healthz`; Flutter prod app smoke confirmed |
+| 2026-04-30 | 1 | Started | — | Phase 1 plan published (`phase-1-me-slice.md`) |

--- a/docs/superpowers/migrations/phase-1-me-slice.md
+++ b/docs/superpowers/migrations/phase-1-me-slice.md
@@ -1,0 +1,3352 @@
+# Phase 1 — `me` slice + API foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the first end-to-end vertical slice. Backend grows `core/api/` middleware (auth, idempotency, request_id, structured logging, error mapping) and a complete `features/me/` (HTTP `GET`/`PATCH /v1/me`, v2-organised auth triggers, repo). Flutter grows `core/api/` (auth-aware client + persistent mutation queue with optimistic-update overlay) and `features/me/` (vertical slice replacing `lib/data/user.dart`). Migration #1 lands the additive user-doc shape, the legacy `cacheJoinHousehold`/`cacheLeaveHousehold` triggers are patched to dual-write the new field name, and `/users/{uid}` is tightened to owner-only **read**.
+
+**Architecture:** Three thin slices that each ship independently.
+- **Slice 1** ships `GET /v1/me` end-to-end (middleware + handler + Dart client + Flutter feature/me read path) without changing storage or replacing legacy code.
+- **Slice 2** ships `PATCH /v1/me` end-to-end, the full `core/api/mutation_queue.dart` (in-memory + persistent + drain on reconnect + idempotency keys), and the Flutter consumers that switch from direct Firestore writes to the API.
+- **Slice 3** swaps in v2 auth triggers (organised under `features/me/triggers.ts`), runs Migration #1 (additive backfill), patches the legacy v1 triggers to dual-write `household_ids`, deletes `lib/data/user.dart`, and tightens the security rule.
+
+Each slice = one PR = one production deploy. The legacy `cacheJoinHousehold`/`cacheLeaveHousehold` callable triggers stay alive (Phase 2 replaces them) but now write both the legacy `households` field and the new `household_ids` field — a surgical bridge that disappears in Phase 2.
+
+**Tech Stack:** Hono + `@hono/zod-openapi`, Firestore Admin SDK, Vitest + `@firebase/rules-unit-testing`, Flutter + `flutter_riverpod` + `freezed` + `dio` (generated), `connectivity_plus`, `shared_preferences`.
+
+**Spec:** [`docs/superpowers/specs/2026-04-24-fling-rewrite-design.md`](../specs/2026-04-24-fling-rewrite-design.md)
+
+**STATUS tracker:** [`docs/superpowers/migrations/STATUS.md`](./STATUS.md)
+
+**Decisions captured during planning** (see Phase 1 brainstorm):
+
+1. **Cross-phase field bridge:** Patch the existing v1 `cacheJoinHousehold` / `cacheLeaveHousehold` triggers to dual-write both `households` and `household_ids` until Phase 2 deletes them.
+2. **`PATCH /v1/me` body:** Accept `currentHouseholdId?` **and** `displayName?` (avoids a churn PR later).
+3. **`mutation_queue.dart` scope:** Full implementation in Phase 1 (in-memory queue + `shared_preferences` persistence + `connectivity_plus` drain + idempotency-key generation). Phase 3 consumes it without further changes.
+4. **Task ordering:** Thin-slice end-to-end. Each of the three slices ships independently.
+
+**Trigger SDK note:** Firebase Functions v2 has no direct `auth.user().onCreate/onDelete` equivalent without Identity Platform blocking triggers. We keep using `firebase-functions/v1`'s `auth.user()` API for the lifecycle triggers but organise them under `features/me/triggers.ts`. Firestore triggers remain on v2 (`firebase-functions/v2/firestore`).
+
+---
+
+## Exit criteria (mirrors STATUS §"Phase 1 — `me` slice + API foundation")
+
+- [ ] `core/api/` middleware: auth, idempotency, request_id, structured logging, error mapping
+- [ ] OpenAPI generation → Dart client pipeline working end-to-end (verified by real `me` schemas, not just `Health`)
+- [ ] `core/api/mutation_queue.dart` implemented with optimistic-update overlay
+- [ ] Backend `features/me/` complete: `GET /v1/me`, `PATCH /v1/me` (full data export and cascading delete ship in Phase 5)
+- [ ] Flutter `features/me/` migrated to vertical slice; old `FlingUser` deleted
+- [ ] `setupUser` / `deleteUser` v1 functions replaced by v2 triggers in `features/me/triggers.ts` (deletion behaviour matches today: delete user doc only; cascade lands in Phase 5)
+- [ ] Migration #1 deployed: user docs gain `email`, `display_name`, `household_ids`, `current_household_id`, audit fields, `schema_version: 1`
+- [ ] Rule tightened: `/users/{uid}` is owner-only read
+
+## File map
+
+Created:
+
+```text
+functions/src/core/context/request_context.ts
+functions/src/core/logger/logger.ts
+functions/src/core/errors/app_error.ts
+functions/src/core/errors/handler.ts
+functions/src/core/middleware/request_id.ts
+functions/src/core/middleware/auth.ts
+functions/src/core/middleware/idempotency.ts
+functions/src/core/idempotency/repo.ts
+functions/src/features/me/schemas.ts
+functions/src/features/me/repo.ts
+functions/src/features/me/service.ts
+functions/src/features/me/routes.ts
+functions/src/features/me/triggers.ts
+functions/src/features/me/events.ts                # placeholder; populated in Phase 5
+functions/migrations/001-user-shape.ts
+functions/test/core/middleware/request_id.test.ts
+functions/test/core/middleware/auth.test.ts
+functions/test/core/middleware/idempotency.test.ts
+functions/test/core/errors/handler.test.ts
+functions/test/features/me/routes.test.ts
+functions/test/features/me/triggers.test.ts
+functions/test/features/me/service.test.ts
+functions/test/migrations/001-user-shape.test.ts
+lib/core/api/api_client.dart
+lib/core/api/mutation_queue.dart
+lib/core/api/idempotency_key.dart
+lib/features/me/domain/me.dart
+lib/features/me/domain/me.freezed.dart            # generated
+lib/features/me/domain/me.g.dart                  # generated
+lib/features/me/data/me_repository.dart
+lib/features/me/application/me_providers.dart
+lib/features/me/presentation/.gitkeep             # already in repo from Phase 0
+test/core/api/mutation_queue_test.dart
+test/features/me/me_repository_test.dart
+test/features/me/me_providers_test.dart
+```
+
+Modified:
+
+```text
+functions/src/api/app.ts                          # mount middleware + features/me routes
+functions/src/index.ts                            # export v2 me triggers; patch legacy triggers; remove v1 setupUser/deleteUser
+firestore.rules                                   # tighten /users/{uid} to owner-only read (final task of Slice 3)
+firestore.indexes.json                            # add idempotency_keys TTL field config note
+lib/main.dart                                     # wrap app in ProviderScope; bootstrap auth interceptor
+lib/pages/lists.dart                              # consume me providers instead of FlingUser
+lib/pages/templates.dart                          # consume me providers instead of FlingUser
+lib/pages/household_add.dart                      # consume me providers instead of FlingUser
+lib/pages/home.dart                               # consume me providers instead of FlingUser
+lib/pages/list.dart                               # consume me providers instead of FlingUser
+lib/pages/template.dart                           # consume me providers instead of FlingUser
+lib/layout/drawer.dart                            # use deleteAccount provider
+lib/data/household.dart                           # read currentHouseholdId from me providers
+docs/superpowers/migrations/STATUS.md             # mark Phase 1 in progress, then complete
+```
+
+Deleted at end of phase:
+
+```text
+lib/data/user.dart                                # FlingUser replaced by features/me/
+```
+
+---
+
+## Task 0: Set up Phase 1 worktree
+
+**Files:**
+- None modified inside repo; sets up an isolated working tree
+
+- [ ] **Step 1: Verify clean baseline on `main`**
+
+```bash
+cd /Users/garrit/src/garritfra/fling
+git fetch origin
+git switch main && git pull --ff-only
+git status
+```
+
+Expected: `nothing to commit, working tree clean`. Phase 0 commit visible in `git log -1`.
+
+- [ ] **Step 2: Create the worktree on a new branch**
+
+```bash
+git worktree add .worktrees/phase-1-me-slice -b phase-1-me-slice main
+cd .worktrees/phase-1-me-slice
+```
+
+Expected: branch `phase-1-me-slice` checked out at `.worktrees/phase-1-me-slice`.
+
+- [ ] **Step 3: Verify baseline tooling works in the worktree**
+
+```bash
+( cd functions && npm ci --no-audit && npm run lint && npm run build && npm test )
+flutter pub get && flutter analyze && flutter test test/smoke_test.dart
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Flip STATUS Phase 1 to In Progress**
+
+In `docs/superpowers/migrations/STATUS.md` change the Phase 1 row in the Overview table from:
+
+```text
+| 1 | `me` slice + API foundation | First end-to-end vertical slice. Replaces `setupUser` / `deleteUser`. | ⬜ | _not yet written_ | — | — |
+```
+
+to:
+
+```text
+| 1 | `me` slice + API foundation | First end-to-end vertical slice. Replaces `setupUser` / `deleteUser`. | 🟡 | [phase-1-me-slice.md](./phase-1-me-slice.md) | YYYY-MM-DD | — |
+```
+
+Update **Last updated** to today. Append change-log entry:
+
+```text
+| YYYY-MM-DD | 1 | Started | — | Phase 1 plan published (`phase-1-me-slice.md`) |
+```
+
+```bash
+git add docs/superpowers/migrations/STATUS.md docs/superpowers/migrations/phase-1-me-slice.md
+git commit -m "docs(rewrite): start Phase 1 (me slice + API foundation)"
+```
+
+---
+
+# SLICE 1 — `GET /v1/me` end-to-end
+
+Goal: a real schema'd endpoint, the auth + request_id + structured logger + error-mapping stack, the OpenAPI → Dart client extension working for non-trivial schemas, and a Flutter `features/me/` that streams the user doc through Riverpod. Storage shape is unchanged; legacy `FlingUser` still exists in parallel.
+
+## Task 1: Backend — `RequestContext` + structured logger
+
+**Files:**
+- Create: `functions/src/core/context/request_context.ts`
+- Create: `functions/src/core/logger/logger.ts`
+- Modify: `functions/src/core/context/index.ts`
+- Modify: `functions/src/core/logger/index.ts`
+- Test: included with Task 2 (these are pure types/utilities consumed there)
+
+`RequestContext` is the per-request bag threaded through services: `{ uid, email, requestId, householdId? }`. It is set by middleware on the Hono context; services receive it as the first argument.
+
+- [ ] **Step 1: Write `RequestContext`**
+
+Replace `functions/src/core/context/index.ts` with:
+
+```ts
+export {RequestContext, getRequestContext} from "./request_context";
+```
+
+Create `functions/src/core/context/request_context.ts`:
+
+```ts
+import type {Context} from "hono";
+
+export interface RequestContext {
+  uid: string;
+  email?: string;
+  requestId: string;
+  householdId?: string;
+}
+
+const KEY = "__fling_request_context";
+
+export function setRequestContext(c: Context, ctx: RequestContext): void {
+  c.set(KEY, ctx);
+}
+
+export function getRequestContext(c: Context): RequestContext {
+  const ctx = c.get(KEY) as RequestContext | undefined;
+  if (!ctx) throw new Error("RequestContext missing — middleware not mounted");
+  return ctx;
+}
+```
+
+- [ ] **Step 2: Write the structured logger**
+
+Replace `functions/src/core/logger/index.ts` with:
+
+```ts
+export {logger, withRequestContext} from "./logger";
+export type {Logger} from "./logger";
+```
+
+Create `functions/src/core/logger/logger.ts`:
+
+```ts
+import type {RequestContext} from "../context/request_context";
+
+export interface Logger {
+  info(msg: string, fields?: Record<string, unknown>): void;
+  warn(msg: string, fields?: Record<string, unknown>): void;
+  error(msg: string, fields?: Record<string, unknown>): void;
+}
+
+function emit(level: "INFO" | "WARN" | "ERROR", msg: string, fields?: Record<string, unknown>): void {
+  const line = JSON.stringify({severity: level, message: msg, ...fields});
+  if (level === "ERROR") console.error(line);
+  else if (level === "WARN") console.warn(line);
+  else console.log(line);
+}
+
+export const logger: Logger = {
+  info: (m, f) => emit("INFO", m, f),
+  warn: (m, f) => emit("WARN", m, f),
+  error: (m, f) => emit("ERROR", m, f),
+};
+
+export function withRequestContext(ctx: RequestContext): Logger {
+  const base = {request_id: ctx.requestId, uid: ctx.uid};
+  return {
+    info: (m, f) => emit("INFO", m, {...base, ...f}),
+    warn: (m, f) => emit("WARN", m, {...base, ...f}),
+    error: (m, f) => emit("ERROR", m, {...base, ...f}),
+  };
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cd functions && npm run build && cd ..
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/src/core/context functions/src/core/logger
+git commit -m "feat(core): add RequestContext + structured logger"
+```
+
+---
+
+## Task 2: Backend — `AppError` hierarchy + error handler middleware
+
+**Files:**
+- Create: `functions/src/core/errors/app_error.ts`
+- Create: `functions/src/core/errors/handler.ts`
+- Modify: `functions/src/core/errors/index.ts`
+- Test: `functions/test/core/errors/handler.test.ts`
+
+The error response shape is fixed by spec §5.3: `{ error: { code, message, details? } }`. We model errors as a single sealed `AppError` class with subclasses; the handler maps unknown errors to `INTERNAL`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `functions/test/core/errors/handler.test.ts`:
+
+```ts
+import {describe, it, expect} from "vitest";
+import {Hono} from "hono";
+import {installErrorHandler} from "../../../src/core/errors/handler";
+import {
+  AppError, BadRequest, Forbidden, NotFound, Conflict, Unauthorized,
+} from "../../../src/core/errors/app_error";
+
+function appWithThrower(thrown: unknown): Hono {
+  const app = new Hono();
+  installErrorHandler(app);
+  app.get("/boom", () => {
+    throw thrown;
+  });
+  return app;
+}
+
+describe("error handler", () => {
+  it("maps Unauthorized → 401", async () => {
+    const res = await appWithThrower(new Unauthorized("bad token")).request("/boom");
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({error: {code: "UNAUTHORIZED", message: "bad token"}});
+  });
+
+  it("maps Forbidden → 403", async () => {
+    const res = await appWithThrower(new Forbidden("nope")).request("/boom");
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("FORBIDDEN");
+  });
+
+  it("maps NotFound → 404", async () => {
+    const res = await appWithThrower(new NotFound("missing")).request("/boom");
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("NOT_FOUND");
+  });
+
+  it("maps Conflict → 409 with details", async () => {
+    const err = new Conflict("idempotency conflict", {key: "abc"});
+    const res = await appWithThrower(err).request("/boom");
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("CONFLICT");
+    expect(body.error.details).toEqual({key: "abc"});
+  });
+
+  it("maps BadRequest → 400", async () => {
+    const res = await appWithThrower(new BadRequest("bad")).request("/boom");
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe("BAD_REQUEST");
+  });
+
+  it("maps unknown errors → 500 INTERNAL with generic message", async () => {
+    const res = await appWithThrower(new Error("kaboom")).request("/boom");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe("INTERNAL");
+    expect(body.error.message).toBe("Internal server error");
+  });
+
+  it("does not leak details on AppError without details", async () => {
+    const res = await appWithThrower(new AppError("X", "msg", 418)).request("/boom");
+    expect(res.status).toBe(418);
+    const body = await res.json();
+    expect(body.error).toEqual({code: "X", message: "msg"});
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd functions && npm test -- test/core/errors/handler.test.ts
+```
+
+Expected: fails with `Cannot find module '.../app_error'`.
+
+- [ ] **Step 3: Write `AppError`**
+
+Create `functions/src/core/errors/app_error.ts`:
+
+```ts
+export class AppError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly status: number,
+    public readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+export class BadRequest extends AppError {
+  constructor(message = "Bad request", details?: Record<string, unknown>) {
+    super("BAD_REQUEST", message, 400, details);
+  }
+}
+
+export class Unauthorized extends AppError {
+  constructor(message = "Unauthorized") {
+    super("UNAUTHORIZED", message, 401);
+  }
+}
+
+export class Forbidden extends AppError {
+  constructor(message = "Forbidden") {
+    super("FORBIDDEN", message, 403);
+  }
+}
+
+export class NotFound extends AppError {
+  constructor(message = "Not found") {
+    super("NOT_FOUND", message, 404);
+  }
+}
+
+export class Conflict extends AppError {
+  constructor(message = "Conflict", details?: Record<string, unknown>) {
+    super("CONFLICT", message, 409, details);
+  }
+}
+```
+
+- [ ] **Step 4: Write the handler**
+
+Create `functions/src/core/errors/handler.ts`:
+
+```ts
+import type {Hono} from "hono";
+import type {OpenAPIHono} from "@hono/zod-openapi";
+import {ZodError} from "zod";
+import {AppError, BadRequest} from "./app_error";
+import {logger} from "../logger";
+
+export function installErrorHandler(app: Hono | OpenAPIHono): void {
+  app.onError((err, c) => {
+    if (err instanceof ZodError) {
+      const wrapped = new BadRequest("Validation failed", {issues: err.issues});
+      return c.json({error: {code: wrapped.code, message: wrapped.message, details: wrapped.details}}, 400);
+    }
+    if (err instanceof AppError) {
+      const body: {error: {code: string; message: string; details?: Record<string, unknown>}} = {
+        error: {code: err.code, message: err.message},
+      };
+      if (err.details) body.error.details = err.details;
+      return c.json(body, err.status as 400 | 401 | 403 | 404 | 409 | 418);
+    }
+    logger.error("Unhandled error", {message: err.message, stack: err.stack});
+    return c.json({error: {code: "INTERNAL", message: "Internal server error"}}, 500);
+  });
+}
+```
+
+- [ ] **Step 5: Re-export from the index barrel**
+
+Replace `functions/src/core/errors/index.ts` with:
+
+```ts
+export * from "./app_error";
+export {installErrorHandler} from "./handler";
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+cd functions && npm test -- test/core/errors/handler.test.ts
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add functions/src/core/errors functions/test/core/errors
+git commit -m "feat(core): add AppError hierarchy + Hono error handler"
+```
+
+---
+
+## Task 3: Backend — `requestId` middleware
+
+**Files:**
+- Create: `functions/src/core/middleware/request_id.ts`
+- Modify: `functions/src/core/middleware/index.ts`
+- Test: `functions/test/core/middleware/request_id.test.ts`
+
+Spec §5.3.1: generate or accept `X-Request-Id`; stamp it on the response and attach to `RequestContext`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `functions/test/core/middleware/request_id.test.ts`:
+
+```ts
+import {describe, it, expect} from "vitest";
+import {Hono} from "hono";
+import {requestIdMiddleware} from "../../../src/core/middleware/request_id";
+
+function appWithRid(): Hono {
+  const app = new Hono();
+  app.use("*", requestIdMiddleware());
+  app.get("/echo", (c) => c.json({rid: c.get("requestId")}));
+  return app;
+}
+
+describe("requestId middleware", () => {
+  it("generates a UUID-shaped id when X-Request-Id is absent", async () => {
+    const app = appWithRid();
+    const res = await app.request("/echo");
+    const body = await res.json();
+    expect(body.rid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(res.headers.get("x-request-id")).toBe(body.rid);
+  });
+
+  it("honours an incoming X-Request-Id", async () => {
+    const app = appWithRid();
+    const res = await app.request("/echo", {headers: {"X-Request-Id": "client-abc-123"}});
+    const body = await res.json();
+    expect(body.rid).toBe("client-abc-123");
+    expect(res.headers.get("x-request-id")).toBe("client-abc-123");
+  });
+
+  it("rejects an X-Request-Id longer than 128 chars and generates a fresh one", async () => {
+    const app = appWithRid();
+    const long = "a".repeat(200);
+    const res = await app.request("/echo", {headers: {"X-Request-Id": long}});
+    const body = await res.json();
+    expect(body.rid).not.toBe(long);
+    expect(body.rid).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd functions && npm test -- test/core/middleware/request_id.test.ts
+```
+
+Expected: fails with `Cannot find module`.
+
+- [ ] **Step 3: Implement the middleware**
+
+Create `functions/src/core/middleware/request_id.ts`:
+
+```ts
+import type {MiddlewareHandler} from "hono";
+import {randomUUID} from "node:crypto";
+
+const MAX_INCOMING_LEN = 128;
+const SAFE_RID = /^[A-Za-z0-9._\-:]+$/;
+
+export function requestIdMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const incoming = c.req.header("x-request-id");
+    const rid = incoming && incoming.length <= MAX_INCOMING_LEN && SAFE_RID.test(incoming)
+      ? incoming
+      : randomUUID();
+    c.set("requestId", rid);
+    c.header("x-request-id", rid);
+    await next();
+  };
+}
+```
+
+- [ ] **Step 4: Update the barrel**
+
+Replace `functions/src/core/middleware/index.ts` with:
+
+```ts
+export {requestIdMiddleware} from "./request_id";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd functions && npm test -- test/core/middleware/request_id.test.ts
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add functions/src/core/middleware/request_id.ts functions/src/core/middleware/index.ts functions/test/core/middleware/request_id.test.ts
+git commit -m "feat(core): add requestId middleware"
+```
+
+---
+
+## Task 4: Backend — `auth` middleware (Firebase ID token verification)
+
+**Files:**
+- Create: `functions/src/core/middleware/auth.ts`
+- Modify: `functions/src/core/middleware/index.ts`
+- Modify: `functions/src/core/auth/index.ts`
+- Test: `functions/test/core/middleware/auth.test.ts`
+
+The auth middleware verifies the Firebase ID token from `Authorization: Bearer <token>`, rejects with `401` on missing/invalid, and writes `RequestContext { uid, email?, requestId }` to the context.
+
+- [ ] **Step 1: Write the failing test (uses the Auth emulator)**
+
+Create `functions/test/core/middleware/auth.test.ts`:
+
+```ts
+import {afterAll, beforeAll, describe, it, expect} from "vitest";
+import {OpenAPIHono} from "@hono/zod-openapi";
+import {requestIdMiddleware} from "../../../src/core/middleware/request_id";
+import {authMiddleware} from "../../../src/core/middleware/auth";
+import {installErrorHandler} from "../../../src/core/errors/handler";
+import {getRequestContext} from "../../../src/core/context/request_context";
+import {initializeApp, deleteApp, getApps} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
+
+let testToken: string;
+
+beforeAll(async () => {
+  if (getApps().length === 0) initializeApp({projectId: "fling-rules-test"});
+  const auth = getAuth();
+  const user = await auth.createUser({email: "alice@example.com"});
+  // Build a custom token, then exchange it for an ID token via the emulator.
+  const customToken = await auth.createCustomToken(user.uid);
+  const r = await fetch(
+    `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake`,
+    {method: "POST", body: JSON.stringify({token: customToken, returnSecureToken: true}), headers: {"Content-Type": "application/json"}},
+  );
+  const body = await r.json() as {idToken: string};
+  testToken = body.idToken;
+});
+
+afterAll(async () => {
+  for (const a of getApps()) await deleteApp(a);
+});
+
+function appWithAuth(): OpenAPIHono {
+  const app = new OpenAPIHono();
+  installErrorHandler(app);
+  app.use("*", requestIdMiddleware());
+  app.use("/v1/*", authMiddleware());
+  app.get("/v1/whoami", (c) => {
+    const {uid, email, requestId} = getRequestContext(c);
+    return c.json({uid, email, requestId});
+  });
+  return app;
+}
+
+describe("auth middleware", () => {
+  it("rejects 401 when Authorization header is missing", async () => {
+    const res = await appWithAuth().request("/v1/whoami");
+    expect(res.status).toBe(401);
+    expect((await res.json()).error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects 401 on a malformed token", async () => {
+    const res = await appWithAuth().request("/v1/whoami", {headers: {Authorization: "Bearer not-a-real-token"}});
+    expect(res.status).toBe(401);
+  });
+
+  it("attaches uid + email to RequestContext on a valid token", async () => {
+    const res = await appWithAuth().request("/v1/whoami", {headers: {Authorization: `Bearer ${testToken}`}});
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.uid).toBeTypeOf("string");
+    expect(body.email).toBe("alice@example.com");
+    expect(body.requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/core/middleware/auth.test.ts"
+```
+
+Expected: fails with `Cannot find module 'auth'`.
+
+- [ ] **Step 3: Implement the middleware**
+
+Create `functions/src/core/middleware/auth.ts`:
+
+```ts
+import type {MiddlewareHandler} from "hono";
+import {Unauthorized} from "../errors/app_error";
+import {setRequestContext} from "../context/request_context";
+import {getApps, initializeApp} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
+
+function ensureAdmin() {
+  if (getApps().length === 0) initializeApp();
+}
+
+export function authMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    ensureAdmin();
+    const header = c.req.header("authorization") ?? "";
+    const m = /^Bearer\s+(.+)$/.exec(header);
+    if (!m) throw new Unauthorized("Missing or malformed Authorization header");
+    let decoded;
+    try {
+      decoded = await getAuth().verifyIdToken(m[1]);
+    } catch {
+      throw new Unauthorized("Invalid token");
+    }
+    const requestId = (c.get("requestId") as string | undefined) ?? "";
+    setRequestContext(c, {uid: decoded.uid, email: decoded.email, requestId});
+    await next();
+  };
+}
+```
+
+- [ ] **Step 4: Update barrels**
+
+Update `functions/src/core/middleware/index.ts`:
+
+```ts
+export {requestIdMiddleware} from "./request_id";
+export {authMiddleware} from "./auth";
+```
+
+Update `functions/src/core/auth/index.ts`:
+
+```ts
+export {authMiddleware} from "../middleware/auth";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/core/middleware/auth.test.ts"
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add functions/src/core/middleware/auth.ts functions/src/core/middleware/index.ts functions/src/core/auth/index.ts functions/test/core/middleware/auth.test.ts
+git commit -m "feat(core): add auth middleware (Firebase ID token verification)"
+```
+
+---
+
+## Task 5: Backend — `features/me` schemas + repo + service + GET route
+
+**Files:**
+- Create: `functions/src/features/me/schemas.ts`
+- Create: `functions/src/features/me/repo.ts`
+- Create: `functions/src/features/me/service.ts`
+- Create: `functions/src/features/me/routes.ts`
+- Create: `functions/src/features/me/events.ts`
+- Modify: `functions/src/features/me/module.ts`
+- Test: `functions/test/features/me/service.test.ts`
+- Test: `functions/test/features/me/routes.test.ts`
+
+The `me` slice is a thin adapter over the user doc. The repo reads the doc; the service applies any defaults; the route validates, calls service, returns JSON.
+
+- [ ] **Step 1: Write the schemas**
+
+Create `functions/src/features/me/schemas.ts`:
+
+```ts
+import {z} from "@hono/zod-openapi";
+
+export const MeSchema = z.object({
+  uid: z.string(),
+  email: z.string().email().nullable(),
+  displayName: z.string().nullable(),
+  householdIds: z.array(z.string()),
+  currentHouseholdId: z.string().nullable(),
+}).openapi("Me");
+
+export const PatchMeSchema = z.object({
+  currentHouseholdId: z.string().min(1).max(128).optional(),
+  displayName: z.string().min(1).max(128).optional(),
+}).strict().openapi("PatchMe");
+
+export type Me = z.infer<typeof MeSchema>;
+export type PatchMe = z.infer<typeof PatchMeSchema>;
+```
+
+- [ ] **Step 2: Write the repo**
+
+Create `functions/src/features/me/repo.ts`:
+
+```ts
+import {getApps, initializeApp} from "firebase-admin/app";
+import {getFirestore, FieldValue} from "firebase-admin/firestore";
+import type {Me} from "./schemas";
+
+function db() {
+  if (getApps().length === 0) initializeApp();
+  return getFirestore();
+}
+
+interface RawUserDoc {
+  email?: string;
+  display_name?: string;
+  household_ids?: string[];
+  current_household_id?: string;
+  // legacy field names — read for backwards compatibility until Phase 6
+  households?: string[];
+  current_household?: string;
+}
+
+export async function readUserDoc(uid: string): Promise<Me | null> {
+  const snap = await db().collection("users").doc(uid).get();
+  if (!snap.exists) return null;
+  const raw = snap.data() as RawUserDoc;
+  return {
+    uid,
+    email: raw.email ?? null,
+    displayName: raw.display_name ?? null,
+    householdIds: raw.household_ids ?? raw.households ?? [],
+    currentHouseholdId: raw.current_household_id ?? raw.current_household ?? null,
+  };
+}
+
+export async function patchUserDoc(uid: string, patch: {
+  currentHouseholdId?: string;
+  displayName?: string;
+}): Promise<void> {
+  const update: Record<string, unknown> = {
+    updated_at: FieldValue.serverTimestamp(),
+  };
+  if (patch.currentHouseholdId !== undefined) {
+    update.current_household_id = patch.currentHouseholdId;
+    // Dual-write the legacy field while Flutter clients still read it.
+    update.current_household = patch.currentHouseholdId;
+  }
+  if (patch.displayName !== undefined) {
+    update.display_name = patch.displayName;
+  }
+  await db().collection("users").doc(uid).set(update, {merge: true});
+}
+
+export async function createUserDoc(uid: string, email: string | null): Promise<void> {
+  await db().collection("users").doc(uid).set({
+    email: email ?? null,
+    display_name: null,
+    household_ids: [],
+    current_household_id: null,
+    households: [],            // legacy, dual-write
+    current_household: null,   // legacy, dual-write
+    schema_version: 1,
+    created_at: FieldValue.serverTimestamp(),
+    updated_at: FieldValue.serverTimestamp(),
+    created_by_uid: uid,
+  }, {merge: true});
+}
+
+export async function deleteUserDoc(uid: string): Promise<void> {
+  await db().collection("users").doc(uid).delete();
+}
+```
+
+- [ ] **Step 3: Write the service**
+
+Create `functions/src/features/me/service.ts`:
+
+```ts
+import type {RequestContext} from "../../core/context/request_context";
+import {NotFound} from "../../core/errors/app_error";
+import type {Me, PatchMe} from "./schemas";
+import * as repo from "./repo";
+
+export async function getMe(ctx: RequestContext): Promise<Me> {
+  const me = await repo.readUserDoc(ctx.uid);
+  if (!me) throw new NotFound("User document not provisioned yet");
+  // Auth-token email always wins over the persisted denormalised value.
+  return {...me, email: ctx.email ?? me.email};
+}
+
+export async function patchMe(ctx: RequestContext, patch: PatchMe): Promise<Me> {
+  await repo.patchUserDoc(ctx.uid, patch);
+  return getMe(ctx);
+}
+
+export async function createUser(uid: string, email: string | null): Promise<void> {
+  await repo.createUserDoc(uid, email);
+}
+
+export async function deleteUser(uid: string): Promise<void> {
+  // Phase 1: delete the user doc only. Phase 5 upgrades this to cascade.
+  await repo.deleteUserDoc(uid);
+}
+```
+
+- [ ] **Step 4: Write the GET route**
+
+Create `functions/src/features/me/routes.ts`:
+
+```ts
+import {OpenAPIHono, createRoute} from "@hono/zod-openapi";
+import {MeSchema, PatchMeSchema} from "./schemas";
+import {getRequestContext} from "../../core/context/request_context";
+import * as service from "./service";
+
+const errorBody = {
+  "application/json": {
+    schema: PatchMeSchema, // placeholder; replaced below
+  },
+};
+
+const getMeRoute = createRoute({
+  method: "get",
+  path: "/v1/me",
+  tags: ["me"],
+  responses: {
+    200: {description: "The caller", content: {"application/json": {schema: MeSchema}}},
+  },
+});
+
+const patchMeRoute = createRoute({
+  method: "patch",
+  path: "/v1/me",
+  tags: ["me"],
+  request: {body: {required: true, content: {"application/json": {schema: PatchMeSchema}}}},
+  responses: {
+    200: {description: "Updated", content: {"application/json": {schema: MeSchema}}},
+  },
+});
+
+export function registerMeRoutes(app: OpenAPIHono): void {
+  app.openapi(getMeRoute, async (c) => {
+    const me = await service.getMe(getRequestContext(c));
+    return c.json(me, 200);
+  });
+
+  app.openapi(patchMeRoute, async (c) => {
+    const patch = c.req.valid("json");
+    const me = await service.patchMe(getRequestContext(c), patch);
+    return c.json(me, 200);
+  });
+}
+
+// Mark `errorBody` as used to keep the import section honest.
+void errorBody;
+```
+
+- [ ] **Step 5: Stub events module (populated in Phase 5)**
+
+Create `functions/src/features/me/events.ts`:
+
+```ts
+// features/me/events: populated in Phase 5 (events bus).
+// Domain events emitted: `me.created.v1`, `me.deleted.v1`, `me.updated.v1`.
+export {};
+```
+
+- [ ] **Step 6: Update the module placeholder**
+
+Replace `functions/src/features/me/module.ts` with:
+
+```ts
+export const FEATURE_NAME = "me" as const;
+export {registerMeRoutes} from "./routes";
+```
+
+- [ ] **Step 7: Write the failing service test**
+
+Create `functions/test/features/me/service.test.ts`:
+
+```ts
+import {beforeAll, beforeEach, afterAll, describe, it, expect} from "vitest";
+import {initializeApp, deleteApp, getApps, type App} from "firebase-admin/app";
+import {getFirestore} from "firebase-admin/firestore";
+import * as service from "../../../src/features/me/service";
+import {NotFound} from "../../../src/core/errors/app_error";
+
+let app: App;
+
+beforeAll(() => {
+  app = getApps()[0] ?? initializeApp({projectId: "fling-rules-test"});
+});
+beforeEach(async () => {
+  const db = getFirestore();
+  const docs = await db.collection("users").listDocuments();
+  await Promise.all(docs.map((d) => d.delete()));
+});
+afterAll(async () => {
+  if (app) await deleteApp(app);
+});
+
+const ctx = {uid: "alice", email: "alice@example.com", requestId: "rid"};
+
+describe("me.service", () => {
+  it("getMe throws NotFound when the user doc does not exist", async () => {
+    await expect(service.getMe(ctx)).rejects.toThrow(NotFound);
+  });
+
+  it("createUser then getMe returns the new doc", async () => {
+    await service.createUser("alice", "alice@example.com");
+    const me = await service.getMe(ctx);
+    expect(me).toEqual({
+      uid: "alice",
+      email: "alice@example.com",
+      displayName: null,
+      householdIds: [],
+      currentHouseholdId: null,
+    });
+  });
+
+  it("patchMe sets currentHouseholdId and dual-writes the legacy field", async () => {
+    await service.createUser("alice", "alice@example.com");
+    await service.patchMe(ctx, {currentHouseholdId: "h1"});
+    const raw = (await getFirestore().doc("users/alice").get()).data();
+    expect(raw?.current_household_id).toBe("h1");
+    expect(raw?.current_household).toBe("h1");
+  });
+
+  it("patchMe sets displayName", async () => {
+    await service.createUser("alice", "alice@example.com");
+    const me = await service.patchMe(ctx, {displayName: "Alice"});
+    expect(me.displayName).toBe("Alice");
+  });
+
+  it("deleteUser removes the doc", async () => {
+    await service.createUser("alice", null);
+    await service.deleteUser("alice");
+    const snap = await getFirestore().doc("users/alice").get();
+    expect(snap.exists).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 8: Write the failing route test**
+
+Create `functions/test/features/me/routes.test.ts`:
+
+```ts
+import {beforeAll, beforeEach, afterAll, describe, it, expect} from "vitest";
+import {OpenAPIHono} from "@hono/zod-openapi";
+import {initializeApp, deleteApp, getApps, type App} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
+import {getFirestore} from "firebase-admin/firestore";
+import {registerMeRoutes} from "../../../src/features/me/module";
+import {requestIdMiddleware} from "../../../src/core/middleware/request_id";
+import {authMiddleware} from "../../../src/core/middleware/auth";
+import {installErrorHandler} from "../../../src/core/errors/handler";
+import * as service from "../../../src/features/me/service";
+
+let firebaseApp: App;
+let aliceToken: string;
+
+async function exchangeCustomTokenForId(customToken: string): Promise<string> {
+  const r = await fetch(
+    `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake`,
+    {method: "POST", body: JSON.stringify({token: customToken, returnSecureToken: true}), headers: {"Content-Type": "application/json"}},
+  );
+  return ((await r.json()) as {idToken: string}).idToken;
+}
+
+beforeAll(async () => {
+  firebaseApp = getApps()[0] ?? initializeApp({projectId: "fling-rules-test"});
+  const u = await getAuth().createUser({email: "alice@example.com"});
+  aliceToken = await exchangeCustomTokenForId(await getAuth().createCustomToken(u.uid));
+  await service.createUser(u.uid, "alice@example.com");
+});
+
+beforeEach(async () => {
+  const db = getFirestore();
+  const users = await db.collection("users").listDocuments();
+  await Promise.all(users.map((d) => d.delete()));
+  // Re-seed alice (token uid is stable across tests).
+  const decoded = await getAuth().verifyIdToken(aliceToken);
+  await service.createUser(decoded.uid, "alice@example.com");
+});
+
+afterAll(async () => {
+  if (firebaseApp) await deleteApp(firebaseApp);
+});
+
+function buildApp(): OpenAPIHono {
+  const app = new OpenAPIHono();
+  installErrorHandler(app);
+  app.use("*", requestIdMiddleware());
+  app.use("/v1/*", authMiddleware());
+  registerMeRoutes(app);
+  return app;
+}
+
+describe("GET /v1/me", () => {
+  it("401 without a token", async () => {
+    const res = await buildApp().request("/v1/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the user doc with auth-token email", async () => {
+    const res = await buildApp().request("/v1/me", {
+      headers: {Authorization: `Bearer ${aliceToken}`},
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.email).toBe("alice@example.com");
+    expect(body.householdIds).toEqual([]);
+    expect(body.currentHouseholdId).toBeNull();
+    expect(body.displayName).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 9: Mount the routes in the API app**
+
+Edit `functions/src/api/app.ts` to add middleware + me routes. Replace the file with:
+
+```ts
+import {OpenAPIHono, createRoute, z} from "@hono/zod-openapi";
+import {requestIdMiddleware, authMiddleware} from "../core/middleware";
+import {installErrorHandler} from "../core/errors";
+import {registerMeRoutes} from "../features/me/module";
+
+const HealthSchema = z.object({
+  status: z.literal("ok"),
+  version: z.string(),
+}).openapi("Health");
+
+const healthzRoute = createRoute({
+  method: "get",
+  path: "/v1/healthz",
+  responses: {
+    200: {description: "Health check", content: {"application/json": {schema: HealthSchema}}},
+  },
+});
+
+export const app = new OpenAPIHono();
+
+installErrorHandler(app);
+app.use("*", requestIdMiddleware());
+
+// Public endpoints (no auth) come before the auth middleware mount.
+app.openapi(healthzRoute, (c) =>
+  c.json({status: "ok" as const, version: process.env.K_REVISION ?? "dev"}),
+);
+
+// Authenticated /v1/* routes.
+app.use("/v1/*", authMiddleware());
+registerMeRoutes(app);
+
+app.doc("/v1/openapi.json", {
+  openapi: "3.0.3",
+  info: {title: "Fling API", version: "1.0.0"},
+});
+```
+
+- [ ] **Step 10: Run the tests against the emulator**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/features/me test/api/healthz.test.ts"
+```
+
+Expected: all `me` tests pass; `healthz` test still passes.
+
+- [ ] **Step 11: Regenerate OpenAPI + Dart client**
+
+```bash
+./scripts/generate-dart-client.sh
+```
+
+Expected: `openapi/openapi.json` now lists `/v1/me` GET + PATCH and includes `Me` + `PatchMe` schemas. `lib/core/api/generated/lib/src/model/me.dart` exists.
+
+- [ ] **Step 12: Verify Flutter still analyses clean**
+
+```bash
+flutter analyze && flutter test test/smoke_test.dart
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add functions/src/features/me functions/src/api/app.ts functions/test/features/me functions/test/core openapi/openapi.json lib/core/api/generated
+git commit -m "feat(api): add features/me with GET + PATCH /v1/me; regenerate Dart client"
+```
+
+---
+
+## Task 6: Flutter — `features/me/` read path + `ProviderScope` bootstrap
+
+**Files:**
+- Modify: `lib/main.dart`
+- Create: `lib/features/me/domain/me.dart`
+- Create: `lib/features/me/data/me_repository.dart`
+- Create: `lib/features/me/application/me_providers.dart`
+- Test: `test/features/me/me_repository_test.dart`
+- Test: `test/features/me/me_providers_test.dart`
+
+This is the Flutter half of Slice 1: Riverpod gets bootstrapped, the `me` feature streams the user doc from Firestore, and a freezed `Me` domain model lands. The legacy `FlingUser` and `provider`-based wiring stay alive in parallel — nothing the user can see has changed.
+
+- [ ] **Step 1: Write the failing repository test**
+
+Create `test/features/me/me_repository_test.dart`:
+
+```dart
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:fling/features/me/data/me_repository.dart';
+import 'package:fling/features/me/domain/me.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MeRepository.watch', () {
+    test('emits Me with new field names when present', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('alice').set({
+        'email': 'alice@example.com',
+        'display_name': 'Alice',
+        'household_ids': ['h1', 'h2'],
+        'current_household_id': 'h1',
+        'schema_version': 1,
+      });
+      final repo = MeRepository(firestore: firestore);
+      final me = await repo.watch('alice').first;
+      expect(me, isNotNull);
+      expect(me!.uid, 'alice');
+      expect(me.email, 'alice@example.com');
+      expect(me.displayName, 'Alice');
+      expect(me.householdIds, ['h1', 'h2']);
+      expect(me.currentHouseholdId, 'h1');
+    });
+
+    test('falls back to legacy field names', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('alice').set({
+        'households': ['h1'],
+        'current_household': 'h1',
+      });
+      final repo = MeRepository(firestore: firestore);
+      final me = await repo.watch('alice').first;
+      expect(me!.householdIds, ['h1']);
+      expect(me.currentHouseholdId, 'h1');
+      expect(me.displayName, isNull);
+      expect(me.email, isNull);
+    });
+
+    test('emits null when the doc does not exist', () async {
+      final firestore = FakeFirebaseFirestore();
+      final repo = MeRepository(firestore: firestore);
+      final me = await repo.watch('ghost').first;
+      expect(me, isNull);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Add `fake_cloud_firestore` as a dev dep**
+
+Append under `dev_dependencies:` in `pubspec.yaml`:
+
+```yaml
+  fake_cloud_firestore: ^2.5.2
+  firebase_auth_mocks: ^0.13.0
+```
+
+```bash
+flutter pub get
+```
+
+- [ ] **Step 3: Run the test (it will fail to compile)**
+
+```bash
+flutter test test/features/me/me_repository_test.dart
+```
+
+Expected: fails — files don't exist.
+
+- [ ] **Step 4: Define the freezed `Me` model**
+
+Create `lib/features/me/domain/me.dart`:
+
+```dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'me.freezed.dart';
+part 'me.g.dart';
+
+@freezed
+class Me with _$Me {
+  const factory Me({
+    required String uid,
+    String? email,
+    String? displayName,
+    @Default(<String>[]) List<String> householdIds,
+    String? currentHouseholdId,
+  }) = _Me;
+
+  factory Me.fromJson(Map<String, dynamic> json) => _$MeFromJson(json);
+
+  factory Me.fromFirestoreDoc(String uid, Map<String, dynamic> data) {
+    return Me(
+      uid: uid,
+      email: data['email'] as String?,
+      displayName: data['display_name'] as String?,
+      householdIds: List<String>.from(
+        (data['household_ids'] ?? data['households'] ?? const <String>[]) as List,
+      ),
+      currentHouseholdId: (data['current_household_id'] ?? data['current_household']) as String?,
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run build_runner to generate the freezed parts**
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+Expected: `me.freezed.dart` + `me.g.dart` written.
+
+- [ ] **Step 6: Implement the repository**
+
+Create `lib/features/me/data/me_repository.dart`:
+
+```dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fling/features/me/domain/me.dart';
+
+class MeRepository {
+  MeRepository({required this.firestore});
+
+  final FirebaseFirestore firestore;
+
+  Stream<Me?> watch(String uid) {
+    return firestore.collection('users').doc(uid).snapshots().map((snap) {
+      final data = snap.data();
+      if (data == null) return null;
+      return Me.fromFirestoreDoc(uid, data);
+    });
+  }
+}
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+```bash
+flutter test test/features/me/me_repository_test.dart
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 8: Define Riverpod providers**
+
+Create `lib/features/me/application/me_providers.dart`:
+
+```dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:fling/features/me/data/me_repository.dart';
+import 'package:fling/features/me/domain/me.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final firestoreProvider = Provider<FirebaseFirestore>((_) => FirebaseFirestore.instance);
+final firebaseAuthProvider = Provider<FirebaseAuth>((_) => FirebaseAuth.instance);
+
+final authStateProvider = StreamProvider<User?>((ref) {
+  return ref.watch(firebaseAuthProvider).authStateChanges();
+});
+
+final meRepositoryProvider = Provider<MeRepository>((ref) {
+  return MeRepository(firestore: ref.watch(firestoreProvider));
+});
+
+final meProvider = StreamProvider<Me?>((ref) {
+  final auth = ref.watch(authStateProvider).valueOrNull;
+  if (auth == null) return Stream.value(null);
+  return ref.watch(meRepositoryProvider).watch(auth.uid);
+});
+
+final currentHouseholdIdProvider = Provider<String?>((ref) {
+  return ref.watch(meProvider).valueOrNull?.currentHouseholdId;
+});
+
+final householdIdsProvider = Provider<List<String>>((ref) {
+  return ref.watch(meProvider).valueOrNull?.householdIds ?? const <String>[];
+});
+```
+
+- [ ] **Step 9: Write the providers test**
+
+Create `test/features/me/me_providers_test.dart`:
+
+```dart
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:fling/features/me/application/me_providers.dart';
+import 'package:fling/features/me/domain/me.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('meProvider streams the current auth user\'s doc', () async {
+    final firestore = FakeFirebaseFirestore();
+    final auth = MockFirebaseAuth(signedIn: true, mockUser: MockUser(uid: 'alice', email: 'alice@example.com'));
+    await firestore.collection('users').doc('alice').set({
+      'email': 'alice@example.com',
+      'household_ids': ['h1'],
+      'current_household_id': 'h1',
+    });
+
+    final container = ProviderContainer(overrides: [
+      firestoreProvider.overrideWithValue(firestore),
+      firebaseAuthProvider.overrideWithValue(auth as FirebaseAuth),
+    ]);
+    addTearDown(container.dispose);
+
+    // Wait for both providers to settle.
+    final me = await container.read(meProvider.future);
+    expect(me, isA<Me>());
+    expect(me!.uid, 'alice');
+    expect(me.currentHouseholdId, 'h1');
+  });
+}
+```
+
+- [ ] **Step 10: Run the test to verify it passes**
+
+```bash
+flutter test test/features/me
+```
+
+Expected: 4 tests pass (3 repo + 1 providers).
+
+- [ ] **Step 11: Wrap the app in `ProviderScope`**
+
+Edit `lib/main.dart`. Replace the `runApp(...)` call and surrounding imports so `ProviderScope` wraps the existing `MultiProvider`:
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+// ... existing imports preserved ...
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+
+  if (kDebugMode) {
+    await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(false);
+  }
+
+  Stream<FlingUser?> user = FlingUser.currentUser;
+
+  runApp(
+    ProviderScope(
+      child: MultiProvider(
+        providers: [
+          StreamProvider<FlingUser?>(
+            create: (context) => user,
+            initialData: null,
+          ),
+        ],
+        child: const FlingApp(),
+      ),
+    ),
+  );
+}
+```
+
+- [ ] **Step 12: Verify Flutter analyses + tests**
+
+```bash
+flutter analyze && flutter test
+```
+
+Expected: 0 errors, all tests pass.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add pubspec.yaml pubspec.lock lib/main.dart lib/features/me test/features/me
+git commit -m "feat(flutter): add features/me Riverpod read path; bootstrap ProviderScope"
+```
+
+---
+
+## Task 7: Slice 1 — open PR, deploy, smoke
+
+**Files:** none modified (release task).
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push -u origin phase-1-me-slice
+gh pr create --title "Phase 1 Slice 1 — GET /v1/me end-to-end" --body "$(cat <<'EOF'
+## Summary
+
+First slice of Phase 1 (`me` slice + API foundation). No user-visible change.
+
+- core/middleware: requestId, auth (Firebase ID token verification)
+- core/errors: AppError hierarchy + Hono onError handler
+- features/me: schemas (Me, PatchMe), repo, service, GET /v1/me route
+- OpenAPI regenerated; Dart client regenerated and committed
+- Flutter: ProviderScope wraps the app; features/me read path streams user doc
+
+## Test plan
+- [ ] CI green (backend, flutter, contracts)
+- [ ] After merge: `curl -H "Authorization: Bearer $(get-id-token)" https://us-central1-fling-list.cloudfunctions.net/api/v1/me` returns the user doc
+- [ ] Flutter app on prod still works exactly as before (no UI consumes the new providers yet)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI green; merge**
+
+- [ ] **Step 3: Production smoke**
+
+After deploy, exchange a real ID token (or use the Firebase console "Get a sign-in token" tool) and call:
+
+```bash
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  "https://us-central1-fling-list.cloudfunctions.net/api/v1/me"
+```
+
+Expected: 200 with the doc shape.
+
+---
+
+# SLICE 2 — `PATCH /v1/me` + mutation queue + idempotency
+
+Goal: idempotent mutations. The full `core/api/mutation_queue.dart` lands and `me`'s patch-paths flow through it. Flutter's `setCurrentHouseholdId` consumers stop writing to Firestore directly and start calling the API. Storage is unchanged from Slice 1; legacy reads still work.
+
+## Task 8: Backend — idempotency middleware + repo
+
+**Files:**
+- Create: `functions/src/core/idempotency/repo.ts`
+- Modify: `functions/src/core/idempotency/index.ts`
+- Create: `functions/src/core/middleware/idempotency.ts`
+- Modify: `functions/src/core/middleware/index.ts`
+- Test: `functions/test/core/middleware/idempotency.test.ts`
+
+Per spec §5.3.3: for write methods (`POST`/`PATCH`/`PUT`/`DELETE`) with `Idempotency-Key`, we look up `idempotency_keys/{uid}_{key}`. On hit with the same body hash + path, replay the stored response. On hit with a different body hash, return 409 `IDEMPOTENCY_CONFLICT`. On miss, run the handler, then store `(status, body, body_hash, expires_at)`. TTL deletion via Firestore TTL on `expires_at`.
+
+> NOTE on TTL config: Firestore TTL must be enabled per-collection-group via the gcloud CLI or the Firebase console. We document and execute this in Task 18 (production deploy).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `functions/test/core/middleware/idempotency.test.ts`:
+
+```ts
+import {beforeEach, beforeAll, afterAll, describe, it, expect} from "vitest";
+import {OpenAPIHono} from "@hono/zod-openapi";
+import {initializeApp, deleteApp, getApps, type App} from "firebase-admin/app";
+import {getFirestore} from "firebase-admin/firestore";
+import {idempotencyMiddleware} from "../../../src/core/middleware/idempotency";
+import {installErrorHandler} from "../../../src/core/errors/handler";
+
+let firebaseApp: App;
+let calls = 0;
+
+function buildApp(): OpenAPIHono {
+  const app = new OpenAPIHono();
+  installErrorHandler(app);
+  // Pretend RequestContext is already on c (idempotency reads c.get('uid')).
+  app.use("*", async (c, next) => {
+    c.set("uid", "alice");
+    c.set("requestId", "rid");
+    await next();
+  });
+  app.use("*", idempotencyMiddleware());
+  app.patch("/echo", async (c) => {
+    calls++;
+    const body = await c.req.json();
+    return c.json({calls, echoed: body}, 200);
+  });
+  return app;
+}
+
+beforeAll(() => {
+  firebaseApp = getApps()[0] ?? initializeApp({projectId: "fling-rules-test"});
+});
+beforeEach(async () => {
+  calls = 0;
+  const db = getFirestore();
+  const docs = await db.collection("idempotency_keys").listDocuments();
+  await Promise.all(docs.map((d) => d.delete()));
+});
+afterAll(async () => {
+  if (firebaseApp) await deleteApp(firebaseApp);
+});
+
+describe("idempotency middleware", () => {
+  it("passes through when no Idempotency-Key is present", async () => {
+    const app = buildApp();
+    const r = await app.request("/echo", {method: "PATCH", body: JSON.stringify({a: 1}), headers: {"Content-Type": "application/json"}});
+    expect(r.status).toBe(200);
+    expect(calls).toBe(1);
+  });
+
+  it("dedupes: same key + same body returns the cached response", async () => {
+    const app = buildApp();
+    const headers = {"Content-Type": "application/json", "Idempotency-Key": "k1"};
+    const body = JSON.stringify({a: 1});
+    const r1 = await app.request("/echo", {method: "PATCH", body, headers});
+    const r2 = await app.request("/echo", {method: "PATCH", body, headers});
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(calls).toBe(1);
+    expect(await r2.json()).toEqual({calls: 1, echoed: {a: 1}});
+  });
+
+  it("returns 409 on key reuse with a different body", async () => {
+    const app = buildApp();
+    const headers = {"Content-Type": "application/json", "Idempotency-Key": "k1"};
+    const r1 = await app.request("/echo", {method: "PATCH", body: JSON.stringify({a: 1}), headers});
+    expect(r1.status).toBe(200);
+    const r2 = await app.request("/echo", {method: "PATCH", body: JSON.stringify({a: 2}), headers});
+    expect(r2.status).toBe(409);
+    expect((await r2.json()).error.code).toBe("CONFLICT");
+  });
+
+  it("partitions keys by uid", async () => {
+    // Build an app where a query param overrides uid for the second call.
+    const app = new OpenAPIHono();
+    installErrorHandler(app);
+    app.use("*", async (c, next) => {
+      const u = c.req.query("uid") ?? "alice";
+      c.set("uid", u);
+      c.set("requestId", "rid");
+      await next();
+    });
+    app.use("*", idempotencyMiddleware());
+    app.patch("/echo", async (c) => {
+      calls++;
+      return c.json({calls}, 200);
+    });
+    const headers = {"Content-Type": "application/json", "Idempotency-Key": "k1"};
+    await app.request("/echo?uid=alice", {method: "PATCH", body: "{}", headers});
+    const r2 = await app.request("/echo?uid=bob", {method: "PATCH", body: "{}", headers});
+    expect(r2.status).toBe(200);
+    expect(calls).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/core/middleware/idempotency.test.ts"
+```
+
+Expected: fails — files don't exist.
+
+- [ ] **Step 3: Implement the repo**
+
+Create `functions/src/core/idempotency/repo.ts`:
+
+```ts
+import {getApps, initializeApp} from "firebase-admin/app";
+import {getFirestore, Timestamp} from "firebase-admin/firestore";
+
+export interface IdempotencyRecord {
+  status: number;
+  body: string;
+  bodyHash: string;
+  contentType: string;
+  expiresAt: Date;
+}
+
+function db() {
+  if (getApps().length === 0) initializeApp();
+  return getFirestore();
+}
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+export function compositeId(uid: string, key: string): string {
+  return `${uid}_${key}`;
+}
+
+export async function lookup(uid: string, key: string): Promise<IdempotencyRecord | null> {
+  const snap = await db().collection("idempotency_keys").doc(compositeId(uid, key)).get();
+  if (!snap.exists) return null;
+  const d = snap.data()!;
+  return {
+    status: d.status,
+    body: d.body,
+    bodyHash: d.body_hash,
+    contentType: d.content_type,
+    expiresAt: (d.expires_at as Timestamp).toDate(),
+  };
+}
+
+export async function save(uid: string, key: string, rec: IdempotencyRecord): Promise<void> {
+  await db().collection("idempotency_keys").doc(compositeId(uid, key)).set({
+    status: rec.status,
+    body: rec.body,
+    body_hash: rec.bodyHash,
+    content_type: rec.contentType,
+    expires_at: Timestamp.fromMillis(Date.now() + TTL_MS),
+  });
+}
+```
+
+Update `functions/src/core/idempotency/index.ts`:
+
+```ts
+export * from "./repo";
+```
+
+- [ ] **Step 4: Implement the middleware**
+
+Create `functions/src/core/middleware/idempotency.ts`:
+
+```ts
+import type {MiddlewareHandler} from "hono";
+import {createHash} from "node:crypto";
+import {Conflict} from "../errors/app_error";
+import {lookup, save} from "../idempotency/repo";
+
+const WRITE_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+export function idempotencyMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    if (!WRITE_METHODS.has(c.req.method)) {
+      await next();
+      return;
+    }
+    const key = c.req.header("idempotency-key");
+    if (!key) {
+      await next();
+      return;
+    }
+    const uid = c.get("uid") as string | undefined;
+    if (!uid) {
+      // Idempotency requires an authenticated principal — pass through if anonymous (auth gate will reject anyway).
+      await next();
+      return;
+    }
+    const rawBody = await c.req.raw.clone().text();
+    const bodyHash = createHash("sha256").update(rawBody).digest("hex");
+
+    const existing = await lookup(uid, key);
+    if (existing) {
+      if (existing.bodyHash !== bodyHash) {
+        throw new Conflict("Idempotency key reused with different body", {key});
+      }
+      return c.body(existing.body, existing.status as 200, {"content-type": existing.contentType});
+    }
+
+    await next();
+
+    const status = c.res.status;
+    const cloned = c.res.clone();
+    const body = await cloned.text();
+    const contentType = cloned.headers.get("content-type") ?? "application/json";
+    if (status >= 200 && status < 300) {
+      await save(uid, key, {status, body, bodyHash, contentType, expiresAt: new Date()});
+    }
+  };
+}
+```
+
+Update `functions/src/core/middleware/index.ts`:
+
+```ts
+export {requestIdMiddleware} from "./request_id";
+export {authMiddleware} from "./auth";
+export {idempotencyMiddleware} from "./idempotency";
+```
+
+- [ ] **Step 5: Mount idempotency in `app.ts`**
+
+Edit `functions/src/api/app.ts` — add the middleware after `authMiddleware`:
+
+```ts
+app.use("/v1/*", authMiddleware());
+app.use("/v1/*", idempotencyMiddleware());
+registerMeRoutes(app);
+```
+
+(Add `idempotencyMiddleware` to the import from `../core/middleware`.)
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/core/middleware/idempotency.test.ts"
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add functions/src/core/idempotency functions/src/core/middleware/idempotency.ts functions/src/core/middleware/index.ts functions/src/api/app.ts functions/test/core/middleware/idempotency.test.ts
+git commit -m "feat(core): add idempotency middleware backed by idempotency_keys collection"
+```
+
+---
+
+## Task 9: Backend — extend the `me` route test for `PATCH /v1/me`
+
+**Files:**
+- Modify: `functions/test/features/me/routes.test.ts`
+
+The PATCH handler already exists from Task 5; this task locks in its integration-tested behaviour now that the idempotency middleware sits in front of it.
+
+- [ ] **Step 1: Add PATCH cases to `routes.test.ts`**
+
+Append to the existing file (inside the `describe("GET /v1/me", ...)` group, add a sibling group):
+
+```ts
+describe("PATCH /v1/me", () => {
+  it("400 on extra fields (zod strict)", async () => {
+    const res = await buildApp().request("/v1/me", {
+      method: "PATCH",
+      headers: {"Content-Type": "application/json", Authorization: `Bearer ${aliceToken}`},
+      body: JSON.stringify({foo: "bar"}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("updates currentHouseholdId and dual-writes the legacy field", async () => {
+    const res = await buildApp().request("/v1/me", {
+      method: "PATCH",
+      headers: {"Content-Type": "application/json", Authorization: `Bearer ${aliceToken}`},
+      body: JSON.stringify({currentHouseholdId: "h-xyz"}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.currentHouseholdId).toBe("h-xyz");
+  });
+
+  it("updates displayName", async () => {
+    const res = await buildApp().request("/v1/me", {
+      method: "PATCH",
+      headers: {"Content-Type": "application/json", Authorization: `Bearer ${aliceToken}`},
+      body: JSON.stringify({displayName: "Alice"}),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).displayName).toBe("Alice");
+  });
+
+  it("idempotency: same key + same body returns the same response without re-running", async () => {
+    const headers = {"Content-Type": "application/json", Authorization: `Bearer ${aliceToken}`, "Idempotency-Key": "patch-1"};
+    const body = JSON.stringify({displayName: "Alice"});
+    const r1 = await buildApp().request("/v1/me", {method: "PATCH", headers, body});
+    const r2 = await buildApp().request("/v1/me", {method: "PATCH", headers, body});
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    const b1 = await r1.json();
+    const b2 = await r2.json();
+    expect(b2).toEqual(b1);
+  });
+
+  it("idempotency: same key + different body returns 409", async () => {
+    const headers = {"Content-Type": "application/json", Authorization: `Bearer ${aliceToken}`, "Idempotency-Key": "patch-2"};
+    const r1 = await buildApp().request("/v1/me", {method: "PATCH", headers, body: JSON.stringify({displayName: "Alice"})});
+    const r2 = await buildApp().request("/v1/me", {method: "PATCH", headers, body: JSON.stringify({displayName: "Bob"})});
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(409);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/features/me"
+```
+
+Expected: 7 tests pass (2 GET + 5 PATCH).
+
+- [ ] **Step 3: Regenerate Dart client (PATCH endpoint enters the spec)**
+
+```bash
+./scripts/generate-dart-client.sh
+flutter analyze && flutter test test/smoke_test.dart
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/test/features/me/routes.test.ts openapi/openapi.json lib/core/api/generated
+git commit -m "test(me): exercise PATCH /v1/me end-to-end (validation + idempotency)"
+```
+
+---
+
+## Task 10: Flutter — `ApiClient` (Dio + Bearer interceptor)
+
+**Files:**
+- Create: `lib/core/api/api_client.dart`
+- Create: `lib/core/api/idempotency_key.dart`
+- Test: `test/core/api/api_client_test.dart`
+
+The generated `dart-dio` client wants a configured Dio with a Bearer auth interceptor. We expose it as a Riverpod provider so feature data layers can inject it.
+
+- [ ] **Step 1: Implement `idempotency_key.dart`**
+
+Create `lib/core/api/idempotency_key.dart`:
+
+```dart
+import 'dart:math';
+
+const _alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+String newIdempotencyKey([Random? rng]) {
+  final r = rng ?? Random.secure();
+  final buf = StringBuffer();
+  for (var i = 0; i < 22; i++) {
+    buf.write(_alphabet[r.nextInt(_alphabet.length)]);
+  }
+  return buf.toString();
+}
+```
+
+- [ ] **Step 2: Implement `api_client.dart`**
+
+Create `lib/core/api/api_client.dart`:
+
+```dart
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:fling/core/api/generated/lib/fling_api.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ApiBaseUrl {
+  ApiBaseUrl(this.url);
+  final String url;
+}
+
+final apiBaseUrlProvider = Provider<ApiBaseUrl>((_) {
+  const url = String.fromEnvironment(
+    'FLING_API_BASE_URL',
+    defaultValue: 'https://us-central1-fling-list.cloudfunctions.net/api',
+  );
+  return ApiBaseUrl(url);
+});
+
+class _BearerAuthInterceptor extends Interceptor {
+  _BearerAuthInterceptor(this._auth);
+  final FirebaseAuth _auth;
+
+  @override
+  Future<void> onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
+    final user = _auth.currentUser;
+    if (user != null) {
+      final token = await user.getIdToken();
+      options.headers['Authorization'] = 'Bearer $token';
+    }
+    handler.next(options);
+  }
+}
+
+final flingApiProvider = Provider<FlingApi>((ref) {
+  final base = ref.watch(apiBaseUrlProvider).url;
+  final auth = FirebaseAuth.instance;
+  final dio = Dio(BaseOptions(baseUrl: base, connectTimeout: const Duration(seconds: 10), receiveTimeout: const Duration(seconds: 30)));
+  dio.interceptors.add(_BearerAuthInterceptor(auth));
+  return FlingApi(dio: dio);
+});
+```
+
+> Note: the exact import path `package:fling/core/api/generated/lib/fling_api.dart` matches the layout the OpenAPI generator produces under `lib/core/api/generated/`. Adjust if a real path inspection in the worktree shows a different filename (the generator emits `<pubName>.dart`, here `fling_api.dart`).
+
+- [ ] **Step 3: Smoke test**
+
+Create `test/core/api/api_client_test.dart`:
+
+```dart
+import 'package:fling/core/api/idempotency_key.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('idempotency keys are 22 chars, alphanumeric', () {
+    for (var i = 0; i < 50; i++) {
+      final k = newIdempotencyKey();
+      expect(k.length, 22);
+      expect(RegExp(r'^[0-9A-Za-z]+$').hasMatch(k), isTrue);
+    }
+  });
+
+  test('idempotency keys are unique across many draws', () {
+    final keys = {for (var i = 0; i < 1000; i++) newIdempotencyKey()};
+    expect(keys.length, 1000);
+  });
+}
+```
+
+```bash
+flutter test test/core/api/api_client_test.dart
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/core/api/api_client.dart lib/core/api/idempotency_key.dart test/core/api/api_client_test.dart
+git commit -m "feat(flutter): add ApiClient (Dio + Bearer auth) and idempotency key generator"
+```
+
+---
+
+## Task 11: Flutter — `mutation_queue.dart` (full implementation)
+
+**Files:**
+- Create: `lib/core/api/mutation_queue.dart`
+- Test: `test/core/api/mutation_queue_test.dart`
+
+Spec §7.5–7.6: optimistic-update overlay, persistent queue, drain on reconnect, idempotent retry. The queue is the merge point between the per-resource Firestore stream (the upstream truth) and the client's pending writes. Because every retry uses the same idempotency key, draining is always safe.
+
+Public surface:
+
+```dart
+abstract class MutationQueue {
+  Future<T> enqueue<T>(MutationSpec<T> spec);
+  Stream<List<PendingMutation>> get pending;
+  /// Apply pending mutations on top of upstream snapshot. Resource-keyed.
+  T overlay<T>(T upstream, T Function(T base, PendingMutation p) reduce, {required String resourceKey});
+  Future<void> drain();
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/api/mutation_queue_test.dart`:
+
+```dart
+import 'dart:async';
+import 'package:fling/core/api/mutation_queue.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _Connectivity {
+  final controller = StreamController<bool>.broadcast();
+  Stream<bool> get stream => controller.stream;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('enqueue runs the call once on success and removes from pending', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final connectivity = _Connectivity();
+    final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
+    var calls = 0;
+    final result = await q.enqueue(MutationSpec<int>(
+      type: 'me.patch',
+      resourceKey: 'me/alice',
+      body: const {'displayName': 'Alice'},
+      call: (key) async { calls++; return 1; },
+    ));
+    expect(result, 1);
+    expect(calls, 1);
+    expect(await q.pending.first, isEmpty);
+  });
+
+  test('on transient failure the mutation stays pending until drain succeeds', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final connectivity = _Connectivity();
+    final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
+    var attempts = 0;
+    final f = q.enqueue(MutationSpec<int>(
+      type: 'me.patch',
+      resourceKey: 'me/alice',
+      body: const {'displayName': 'Alice'},
+      call: (key) async {
+        attempts++;
+        if (attempts < 2) throw const NetworkFailure();
+        return 1;
+      },
+    ));
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    expect((await q.pending.first).length, 1);
+    connectivity.controller.add(true);
+    expect(await f, 1);
+    expect(attempts, 2);
+    expect(await q.pending.first, isEmpty);
+  });
+
+  test('on permanent failure (4xx non-409) the mutation is dropped and rethrown', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final connectivity = _Connectivity();
+    final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
+    Object? caught;
+    try {
+      await q.enqueue(MutationSpec<int>(
+        type: 'me.patch',
+        resourceKey: 'me/alice',
+        body: const {'displayName': ''},
+        call: (key) async => throw const ApiFailure(400, 'BAD_REQUEST', 'too short'),
+      ));
+    } catch (e) { caught = e; }
+    expect(caught, isA<ApiFailure>());
+    expect(await q.pending.first, isEmpty);
+  });
+
+  test('persists pending mutations across instances', () async {
+    SharedPreferences.setMockInitialValues({});
+    var prefs = await SharedPreferences.getInstance();
+    final connectivity1 = _Connectivity();
+    final q1 = MutationQueueImpl(prefs: prefs, online: connectivity1.stream);
+    // Enqueue without awaiting; force a transient failure by never going online.
+    final completer = Completer<int>();
+    unawaited(q1.enqueue(MutationSpec<int>(
+      type: 'me.patch',
+      resourceKey: 'me/alice',
+      body: const {'displayName': 'A'},
+      call: (key) async {
+        if (!completer.isCompleted) throw const NetworkFailure();
+        return 1;
+      },
+    )).then(completer.complete, onError: (_) {}));
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    expect((await q1.pending.first).length, 1);
+
+    // Recreate the queue from the same prefs; pending must survive.
+    prefs = await SharedPreferences.getInstance();
+    final connectivity2 = _Connectivity();
+    final q2 = MutationQueueImpl(prefs: prefs, online: connectivity2.stream);
+    expect((await q2.pending.first).length, 1);
+  });
+
+  test('overlay applies pending mutations to upstream', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final connectivity = _Connectivity();
+    final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
+    final completer = Completer<int>();
+    unawaited(q.enqueue(MutationSpec<int>(
+      type: 'me.patch',
+      resourceKey: 'me/alice',
+      body: const {'displayName': 'Optimistic'},
+      call: (key) async {
+        await completer.future;
+        return 1;
+      },
+    )));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    final base = {'displayName': 'Old'};
+    final overlaid = q.overlay<Map<String, Object?>>(
+      base,
+      (base, p) => {...base, ...p.body},
+      resourceKey: 'me/alice',
+    );
+    expect(overlaid['displayName'], 'Optimistic');
+    completer.complete(1);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test (will fail to compile)**
+
+```bash
+flutter test test/core/api/mutation_queue_test.dart
+```
+
+Expected: fails — file doesn't exist.
+
+- [ ] **Step 3: Implement `mutation_queue.dart`**
+
+Create `lib/core/api/mutation_queue.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:fling/core/api/idempotency_key.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class NetworkFailure implements Exception {
+  const NetworkFailure();
+}
+
+class ApiFailure implements Exception {
+  const ApiFailure(this.status, this.code, this.message);
+  final int status;
+  final String code;
+  final String message;
+  @override
+  String toString() => 'ApiFailure($status, $code): $message';
+}
+
+class MutationSpec<T> {
+  MutationSpec({
+    required this.type,
+    required this.resourceKey,
+    required this.body,
+    required this.call,
+    this.idempotencyKey,
+  });
+  final String type;
+  final String resourceKey;
+  final Map<String, Object?> body;
+  final String? idempotencyKey;
+  final Future<T> Function(String idempotencyKey) call;
+}
+
+class PendingMutation {
+  PendingMutation({
+    required this.idempotencyKey,
+    required this.type,
+    required this.resourceKey,
+    required this.body,
+    required this.createdAt,
+    this.attempts = 0,
+  });
+  final String idempotencyKey;
+  final String type;
+  final String resourceKey;
+  final Map<String, Object?> body;
+  final DateTime createdAt;
+  int attempts;
+
+  Map<String, Object?> toJson() => {
+        'idempotencyKey': idempotencyKey,
+        'type': type,
+        'resourceKey': resourceKey,
+        'body': body,
+        'createdAt': createdAt.toIso8601String(),
+        'attempts': attempts,
+      };
+
+  factory PendingMutation.fromJson(Map<String, Object?> j) => PendingMutation(
+        idempotencyKey: j['idempotencyKey']! as String,
+        type: j['type']! as String,
+        resourceKey: j['resourceKey']! as String,
+        body: Map<String, Object?>.from(j['body'] as Map),
+        createdAt: DateTime.parse(j['createdAt']! as String),
+        attempts: (j['attempts'] as int?) ?? 0,
+      );
+}
+
+abstract class MutationQueue {
+  Future<T> enqueue<T>(MutationSpec<T> spec);
+  Stream<List<PendingMutation>> get pending;
+  T overlay<T>(T upstream, T Function(T base, PendingMutation p) reduce, {required String resourceKey});
+  Future<void> drain();
+}
+
+class MutationQueueImpl implements MutationQueue {
+  MutationQueueImpl({required this.prefs, required Stream<bool> online})
+      : _online = online {
+    _load();
+    _online.listen((isOnline) {
+      if (isOnline) drain();
+    });
+  }
+
+  static const _prefsKey = 'fling.mutation_queue.v1';
+  final SharedPreferences prefs;
+  final Stream<bool> _online;
+  final _controller = StreamController<List<PendingMutation>>.broadcast();
+  final List<PendingMutation> _queue = [];
+  final Map<String, Completer<dynamic>> _completers = {};
+  final Map<String, Future<dynamic> Function(String)> _calls = {};
+
+  void _load() {
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return;
+    final list = (jsonDecode(raw) as List).cast<Map<String, Object?>>();
+    _queue.addAll(list.map(PendingMutation.fromJson));
+    _emit();
+  }
+
+  Future<void> _persist() async {
+    await prefs.setString(_prefsKey, jsonEncode(_queue.map((p) => p.toJson()).toList()));
+  }
+
+  void _emit() {
+    _controller.add(List.unmodifiable(_queue));
+  }
+
+  @override
+  Stream<List<PendingMutation>> get pending {
+    Future<void>.microtask(_emit);
+    return _controller.stream;
+  }
+
+  @override
+  Future<T> enqueue<T>(MutationSpec<T> spec) async {
+    final key = spec.idempotencyKey ?? newIdempotencyKey();
+    final p = PendingMutation(
+      idempotencyKey: key,
+      type: spec.type,
+      resourceKey: spec.resourceKey,
+      body: spec.body,
+      createdAt: DateTime.now().toUtc(),
+    );
+    _queue.add(p);
+    final completer = Completer<T>();
+    _completers[key] = completer;
+    _calls[key] = spec.call;
+    await _persist();
+    _emit();
+    unawaited(_runOne(p));
+    return completer.future;
+  }
+
+  Future<void> _runOne(PendingMutation p) async {
+    final call = _calls[p.idempotencyKey];
+    final completer = _completers[p.idempotencyKey];
+    if (call == null || completer == null) return;
+    p.attempts++;
+    try {
+      final result = await call(p.idempotencyKey);
+      _queue.removeWhere((q) => q.idempotencyKey == p.idempotencyKey);
+      _completers.remove(p.idempotencyKey);
+      _calls.remove(p.idempotencyKey);
+      completer.complete(result);
+    } on NetworkFailure {
+      // Stay pending; retried on next drain / connectivity event.
+    } on ApiFailure catch (e) {
+      // 409 is conflict — keep pending only if it's an idempotency conflict the server may resolve later.
+      // Otherwise drop and rethrow to caller.
+      if (e.status >= 400 && e.status < 500 && e.status != 409) {
+        _queue.removeWhere((q) => q.idempotencyKey == p.idempotencyKey);
+        _completers.remove(p.idempotencyKey);
+        _calls.remove(p.idempotencyKey);
+        completer.completeError(e);
+      }
+    } catch (e) {
+      // Unknown error — treat as transient.
+    } finally {
+      await _persist();
+      _emit();
+    }
+  }
+
+  @override
+  Future<void> drain() async {
+    final snapshot = List<PendingMutation>.from(_queue);
+    for (final p in snapshot) {
+      await _runOne(p);
+    }
+  }
+
+  @override
+  T overlay<T>(T upstream, T Function(T base, PendingMutation p) reduce, {required String resourceKey}) {
+    var acc = upstream;
+    for (final p in _queue) {
+      if (p.resourceKey == resourceKey) acc = reduce(acc, p);
+    }
+    return acc;
+  }
+}
+
+final connectivityOnlineProvider = StreamProvider<bool>((ref) {
+  return Connectivity().onConnectivityChanged.map(
+        (results) => results.any((r) => r != ConnectivityResult.none),
+      );
+});
+
+final mutationQueueProvider = FutureProvider<MutationQueue>((ref) async {
+  final prefs = await SharedPreferences.getInstance();
+  final online = ref
+      .watch(connectivityOnlineProvider.stream)
+      .asBroadcastStream();
+  return MutationQueueImpl(prefs: prefs, online: online);
+});
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+flutter test test/core/api/mutation_queue_test.dart
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/api/mutation_queue.dart test/core/api/mutation_queue_test.dart
+git commit -m "feat(core/api): full mutation queue (in-memory + persistent + drain on reconnect)"
+```
+
+---
+
+## Task 12: Flutter — wire `me` writes through the API + mutation queue
+
+**Files:**
+- Modify: `lib/features/me/data/me_repository.dart`
+- Modify: `lib/features/me/application/me_providers.dart`
+- Test: extend `test/features/me/me_providers_test.dart`
+
+The repo grows two write methods that go through the API client + mutation queue. The `MeRepository` reads through the queue's overlay so the UI stays optimistic until the Firestore stream catches up.
+
+- [ ] **Step 1: Extend the repository**
+
+Replace `lib/features/me/data/me_repository.dart` with:
+
+```dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:dio/dio.dart';
+import 'package:fling/core/api/generated/lib/fling_api.dart';
+import 'package:fling/core/api/mutation_queue.dart';
+import 'package:fling/features/me/domain/me.dart';
+
+class MeRepository {
+  MeRepository({
+    required this.firestore,
+    required this.api,
+    required this.mutations,
+  });
+
+  final FirebaseFirestore firestore;
+  final FlingApi api;
+  final MutationQueue mutations;
+
+  Stream<Me?> watch(String uid) {
+    return firestore.collection('users').doc(uid).snapshots().map((snap) {
+      final data = snap.data();
+      if (data == null) return null;
+      final base = Me.fromFirestoreDoc(uid, data);
+      return mutations.overlay<Me>(
+        base,
+        (b, p) => _applyPatch(b, p.body),
+        resourceKey: 'me/$uid',
+      );
+    });
+  }
+
+  Me _applyPatch(Me base, Map<String, Object?> patch) {
+    return base.copyWith(
+      currentHouseholdId:
+          (patch['currentHouseholdId'] as String?) ?? base.currentHouseholdId,
+      displayName: (patch['displayName'] as String?) ?? base.displayName,
+    );
+  }
+
+  Future<void> setCurrentHouseholdId(String uid, String householdId) async {
+    final body = {'currentHouseholdId': householdId};
+    await mutations.enqueue(MutationSpec<void>(
+      type: 'me.patch',
+      resourceKey: 'me/$uid',
+      body: body,
+      call: (key) async {
+        try {
+          await api.getDefaultApi().patchV1Me(
+                idempotencyKey: key,
+                patchMe: PatchMe((b) => b..currentHouseholdId = householdId),
+              );
+        } on DioException catch (e) {
+          throw _toFailure(e);
+        }
+      },
+    ));
+  }
+
+  Future<void> setDisplayName(String uid, String displayName) async {
+    final body = {'displayName': displayName};
+    await mutations.enqueue(MutationSpec<void>(
+      type: 'me.patch',
+      resourceKey: 'me/$uid',
+      body: body,
+      call: (key) async {
+        try {
+          await api.getDefaultApi().patchV1Me(
+                idempotencyKey: key,
+                patchMe: PatchMe((b) => b..displayName = displayName),
+              );
+        } on DioException catch (e) {
+          throw _toFailure(e);
+        }
+      },
+    ));
+  }
+
+  Object _toFailure(DioException e) {
+    final status = e.response?.statusCode;
+    if (status == null) return const NetworkFailure();
+    final body = e.response?.data;
+    final code = (body is Map && body['error'] is Map)
+        ? (body['error']['code'] as String? ?? 'UNKNOWN')
+        : 'UNKNOWN';
+    final message = (body is Map && body['error'] is Map)
+        ? (body['error']['message'] as String? ?? e.message ?? '')
+        : (e.message ?? '');
+    return ApiFailure(status, code, message);
+  }
+}
+```
+
+> Note: the actual generated method name (`patchV1Me` and the `getDefaultApi()` accessor) reflects what `openapi-generator-cli`'s `dart-dio` template produces from a route tagged `me` with operationId `patchV1Me`. After regenerating in Task 9, confirm the names by reading `lib/core/api/generated/lib/src/api/default_api.dart` (the file is committed) and adjust the calls if the generator chose a different name.
+
+- [ ] **Step 2: Update providers**
+
+Replace `lib/features/me/application/me_providers.dart` with:
+
+```dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:fling/core/api/api_client.dart';
+import 'package:fling/core/api/mutation_queue.dart';
+import 'package:fling/features/me/data/me_repository.dart';
+import 'package:fling/features/me/domain/me.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final firestoreProvider = Provider<FirebaseFirestore>((_) => FirebaseFirestore.instance);
+final firebaseAuthProvider = Provider<FirebaseAuth>((_) => FirebaseAuth.instance);
+
+final authStateProvider = StreamProvider<User?>((ref) {
+  return ref.watch(firebaseAuthProvider).authStateChanges();
+});
+
+final meRepositoryProvider = FutureProvider<MeRepository>((ref) async {
+  final mutations = await ref.watch(mutationQueueProvider.future);
+  return MeRepository(
+    firestore: ref.watch(firestoreProvider),
+    api: ref.watch(flingApiProvider),
+    mutations: mutations,
+  );
+});
+
+final meProvider = StreamProvider<Me?>((ref) async* {
+  final auth = ref.watch(authStateProvider).valueOrNull;
+  if (auth == null) {
+    yield null;
+    return;
+  }
+  final repo = await ref.watch(meRepositoryProvider.future);
+  yield* repo.watch(auth.uid);
+});
+
+final currentHouseholdIdProvider = Provider<String?>((ref) {
+  return ref.watch(meProvider).valueOrNull?.currentHouseholdId;
+});
+
+final householdIdsProvider = Provider<List<String>>((ref) {
+  return ref.watch(meProvider).valueOrNull?.householdIds ?? const <String>[];
+});
+
+class MeController {
+  MeController(this._ref);
+  final Ref _ref;
+
+  Future<void> setCurrentHousehold(String householdId) async {
+    final auth = _ref.read(firebaseAuthProvider).currentUser;
+    if (auth == null) return;
+    final repo = await _ref.read(meRepositoryProvider.future);
+    await repo.setCurrentHouseholdId(auth.uid, householdId);
+  }
+
+  Future<void> setDisplayName(String displayName) async {
+    final auth = _ref.read(firebaseAuthProvider).currentUser;
+    if (auth == null) return;
+    final repo = await _ref.read(meRepositoryProvider.future);
+    await repo.setDisplayName(auth.uid, displayName);
+  }
+}
+
+final meControllerProvider = Provider<MeController>(MeController.new);
+```
+
+- [ ] **Step 3: Verify analyse + tests**
+
+```bash
+flutter analyze && flutter test test/features/me test/core
+```
+
+Expected: clean. The earlier `me_repository_test.dart` from Task 6 needs updates because the constructor signature changed; update it:
+
+In `test/features/me/me_repository_test.dart`, change every `MeRepository(firestore: firestore)` to:
+
+```dart
+MeRepository(firestore: firestore, api: _NoopApi(), mutations: _NoopQueue())
+```
+
+Then add at the bottom of the file:
+
+```dart
+class _NoopApi implements FlingApi {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _NoopQueue implements MutationQueue {
+  @override
+  Future<T> enqueue<T>(MutationSpec<T> spec) => spec.call('test');
+  @override
+  Stream<List<PendingMutation>> get pending => const Stream.empty();
+  @override
+  T overlay<T>(T upstream, T Function(T base, PendingMutation p) reduce, {required String resourceKey}) => upstream;
+  @override
+  Future<void> drain() async {}
+}
+```
+
+(Add `import 'package:fling/core/api/generated/lib/fling_api.dart';` and `import 'package:fling/core/api/mutation_queue.dart';` to the test file.)
+
+```bash
+flutter test test/features/me test/core
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/features/me test/features/me
+git commit -m "feat(flutter/me): wire setCurrentHouseholdId + setDisplayName via API + mutation queue"
+```
+
+---
+
+## Task 13: Flutter — switch existing pages to the new providers
+
+**Files:**
+- Modify: `lib/pages/lists.dart`
+- Modify: `lib/pages/templates.dart`
+- Modify: `lib/pages/household_add.dart`
+- Modify: `lib/data/household.dart`
+
+We swap the four call sites that today write `current_household` directly. `FlingUser` is **not** deleted yet (Slice 3 does that); legacy reads can coexist. The new write goes through the API.
+
+- [ ] **Step 1: Update `lib/pages/household_add.dart`**
+
+Find the call:
+
+```dart
+user?.setCurrentHouseholdId(household.id!);
+```
+
+Convert the surrounding widget to a `ConsumerStatefulWidget` (or use `Consumer` inline) and replace the call with:
+
+```dart
+await ref.read(meControllerProvider).setCurrentHousehold(household.id!);
+```
+
+Add `import 'package:fling/features/me/application/me_providers.dart';` and `import 'package:flutter_riverpod/flutter_riverpod.dart';`.
+
+- [ ] **Step 2: Update `lib/pages/lists.dart` and `lib/pages/templates.dart`**
+
+Replace each:
+
+```dart
+user?.setCurrentHouseholdId(id);
+```
+
+with:
+
+```dart
+await ref.read(meControllerProvider).setCurrentHousehold(id);
+```
+
+Replace each read of `user?.currentHouseholdId` with `ref.watch(currentHouseholdIdProvider)`.
+
+Make the surrounding widgets `ConsumerWidget` / `ConsumerStatefulWidget` as needed.
+
+- [ ] **Step 3: Update `lib/data/household.dart`**
+
+Replace:
+
+```dart
+Future<DocumentReference> get ref async {
+  FlingUser? user = await FlingUser.currentUser.first;
+  return firestore.collection("households").doc(user?.currentHouseholdId);
+}
+```
+
+with a method that takes `currentHouseholdId` as a parameter (callers pass `ref.watch(currentHouseholdIdProvider)`):
+
+```dart
+DocumentReference refFor(String currentHouseholdId) {
+  return firestore.collection("households").doc(currentHouseholdId);
+}
+```
+
+Update all internal uses (`save`, `leave`, `lists`, `templates`) to take the id as a parameter, and update each caller site to pass `ref.read(currentHouseholdIdProvider)!`.
+
+- [ ] **Step 4: Verify analyse + tests + run app locally**
+
+```bash
+flutter analyze && flutter test
+./scripts/dev.sh &
+DEV_PID=$!
+sleep 12
+flutter run -d chrome --dart-define=FLING_API_BASE_URL=http://127.0.0.1:5001/fling-list/us-central1/api &
+APP_PID=$!
+# Manually exercise: log in, switch household, observe lists update.
+sleep 30
+kill $APP_PID $DEV_PID 2>/dev/null || true
+```
+
+Expected: switching household triggers `PATCH /v1/me` (visible in emulator UI logs). Lists page renders after switching.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/pages lib/data/household.dart
+git commit -m "refactor(flutter): move household-switch to me API; consume currentHouseholdIdProvider"
+```
+
+---
+
+## Task 14: Slice 2 — open PR, deploy, smoke
+
+**Files:** none modified.
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+git push
+gh pr create --title "Phase 1 Slice 2 — PATCH /v1/me + mutation queue" --body "$(cat <<'EOF'
+## Summary
+
+Second slice of Phase 1.
+
+- core middleware: idempotency (Firestore-backed, partitioned by uid)
+- features/me: PATCH /v1/me (currentHouseholdId? + displayName?) with full integration coverage
+- Flutter core/api: ApiClient (Dio + Bearer interceptor), idempotency-key generator
+- Flutter core/api/mutation_queue.dart: full implementation (in-memory + shared_preferences persist + connectivity_plus drain)
+- Flutter features/me/data/me_repository.dart now writes via API + mutation queue, reads via Firestore + optimistic overlay
+- Existing pages (lists, templates, household_add, household.dart) consume currentHouseholdIdProvider instead of FlingUser.setCurrentHouseholdId
+
+Storage shape unchanged. Legacy FlingUser still alive (Slice 3 deletes it).
+
+## Test plan
+- [ ] CI green
+- [ ] After deploy: enable Firestore TTL on idempotency_keys.expires_at (one-time):
+      gcloud firestore fields ttls update expires_at \
+        --collection-group=idempotency_keys --enable-ttl --project=fling-list
+- [ ] Log into prod app; switch household; confirm:
+      - UI updates immediately (optimistic overlay)
+      - PATCH /v1/me visible in cloud logs with the correct uid
+      - users/{uid}.current_household_id and .current_household both updated in Firestore
+EOF
+)"
+```
+
+- [ ] **Step 2: After merge, enable TTL on `idempotency_keys`**
+
+```bash
+gcloud firestore fields ttls update expires_at \
+  --collection-group=idempotency_keys --enable-ttl --project=fling-list
+```
+
+Expected: TTL configuration succeeds. Re-runs are no-ops.
+
+- [ ] **Step 3: Production smoke**
+
+In the prod web app, switch household. Confirm:
+- The list view re-renders to the new household's lists (Firestore stream catches up).
+- Cloud Functions logs show `PATCH /v1/me` with structured `request_id`.
+- `users/{uid}` doc in Firestore shows both `current_household` and `current_household_id`.
+
+---
+
+# SLICE 3 — triggers, migration, rule tighten
+
+Goal: cut the v1 setup/delete triggers, run Migration #1 on prod data, dual-write the legacy member triggers, retire `FlingUser`, and tighten the security rule on `/users/{uid}` to read-only.
+
+## Task 15: Backend — `features/me/triggers.ts` (v2-organised auth lifecycle)
+
+**Files:**
+- Create: `functions/src/features/me/triggers.ts`
+- Modify: `functions/src/index.ts`
+- Test: `functions/test/features/me/triggers.test.ts`
+
+The lifecycle triggers run on user-create / user-delete. We keep the v1 SDK syntax (`firebase-functions/v1`'s `auth.user()` is the supported way until Identity Platform blocking triggers replace it). Organisation moves to `features/me/triggers.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `functions/test/features/me/triggers.test.ts`:
+
+```ts
+import {beforeAll, beforeEach, afterAll, describe, it, expect} from "vitest";
+import {initializeApp, deleteApp, getApps, type App} from "firebase-admin/app";
+import {getFirestore} from "firebase-admin/firestore";
+import {handleUserCreated, handleUserDeleted} from "../../../src/features/me/triggers";
+
+let app: App;
+
+beforeAll(() => {
+  app = getApps()[0] ?? initializeApp({projectId: "fling-rules-test"});
+});
+beforeEach(async () => {
+  const docs = await getFirestore().collection("users").listDocuments();
+  await Promise.all(docs.map((d) => d.delete()));
+});
+afterAll(async () => { if (app) await deleteApp(app); });
+
+describe("me triggers", () => {
+  it("handleUserCreated writes the new doc shape", async () => {
+    await handleUserCreated({uid: "alice", email: "alice@example.com"});
+    const data = (await getFirestore().doc("users/alice").get()).data();
+    expect(data?.email).toBe("alice@example.com");
+    expect(data?.household_ids).toEqual([]);
+    expect(data?.current_household_id).toBeNull();
+    expect(data?.households).toEqual([]);             // legacy dual-write
+    expect(data?.current_household).toBeNull();       // legacy dual-write
+    expect(data?.schema_version).toBe(1);
+    expect(data?.created_at).toBeDefined();
+  });
+
+  it("handleUserDeleted removes the doc", async () => {
+    await handleUserCreated({uid: "alice", email: null});
+    await handleUserDeleted({uid: "alice"});
+    expect((await getFirestore().doc("users/alice").get()).exists).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test (will fail)**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/features/me/triggers.test.ts"
+```
+
+- [ ] **Step 3: Implement the triggers**
+
+Create `functions/src/features/me/triggers.ts`:
+
+```ts
+import * as functionsV1 from "firebase-functions/v1";
+import {createUser, deleteUser} from "./service";
+
+export interface AuthUserLike {
+  uid: string;
+  email?: string | null;
+}
+
+export async function handleUserCreated(user: AuthUserLike): Promise<void> {
+  await createUser(user.uid, user.email ?? null);
+}
+
+export async function handleUserDeleted(user: AuthUserLike): Promise<void> {
+  await deleteUser(user.uid);
+}
+
+export const onUserCreated = functionsV1.auth.user().onCreate((u) =>
+  handleUserCreated({uid: u.uid, email: u.email ?? null}),
+);
+
+export const onUserDeleted = functionsV1.auth.user().onDelete((u) =>
+  handleUserDeleted({uid: u.uid, email: u.email ?? null}),
+);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/features/me/triggers.test.ts"
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions/src/features/me/triggers.ts functions/test/features/me/triggers.test.ts
+git commit -m "feat(me): add v2-organised auth lifecycle triggers in features/me/triggers.ts"
+```
+
+---
+
+## Task 16: Migration #1 — additive backfill of user-doc shape
+
+**Files:**
+- Create: `functions/migrations/001-user-shape.ts`
+- Test: `functions/test/migrations/001-user-shape.test.ts`
+
+For every `users/{uid}` doc, set the new fields if missing:
+- `email` ← Firebase Auth user record's email (best-effort; null if not found)
+- `display_name` ← null
+- `household_ids` ← copy of `households` (or `[]`)
+- `current_household_id` ← copy of `current_household` (or null)
+- `schema_version` ← 1
+- `created_at` / `updated_at` ← server timestamp
+- `created_by_uid` ← the doc's own uid
+
+Idempotent: skips docs that already have `schema_version: 1`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `functions/test/migrations/001-user-shape.test.ts`:
+
+```ts
+import {beforeAll, beforeEach, afterAll, describe, it, expect} from "vitest";
+import {initializeApp, deleteApp, getApps, type App} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
+import {getFirestore} from "firebase-admin/firestore";
+import migration from "../../migrations/001-user-shape";
+
+let app: App;
+
+beforeAll(() => {
+  app = getApps()[0] ?? initializeApp({projectId: "fling-rules-test"});
+});
+beforeEach(async () => {
+  const docs = await getFirestore().collection("users").listDocuments();
+  await Promise.all(docs.map((d) => d.delete()));
+  const users = await getAuth().listUsers();
+  await Promise.all(users.users.map((u) => getAuth().deleteUser(u.uid)));
+});
+afterAll(async () => { if (app) await deleteApp(app); });
+
+describe("migration 001-user-shape", () => {
+  it("backfills new fields from legacy fields", async () => {
+    await getAuth().createUser({uid: "alice", email: "alice@example.com"});
+    await getFirestore().doc("users/alice").set({
+      households: ["h1"],
+      current_household: "h1",
+    });
+    await migration.up();
+    const data = (await getFirestore().doc("users/alice").get()).data()!;
+    expect(data.email).toBe("alice@example.com");
+    expect(data.household_ids).toEqual(["h1"]);
+    expect(data.current_household_id).toBe("h1");
+    expect(data.schema_version).toBe(1);
+    expect(data.households).toEqual(["h1"]);          // legacy preserved
+    expect(data.current_household).toBe("h1");        // legacy preserved
+  });
+
+  it("is idempotent — re-running does not re-stamp created_at", async () => {
+    await getAuth().createUser({uid: "alice", email: "alice@example.com"});
+    await getFirestore().doc("users/alice").set({households: []});
+    await migration.up();
+    const a = (await getFirestore().doc("users/alice").get()).data()!.created_at;
+    await migration.up();
+    const b = (await getFirestore().doc("users/alice").get()).data()!.created_at;
+    expect(b).toEqual(a);
+  });
+
+  it("handles users with no auth record (email becomes null)", async () => {
+    await getFirestore().doc("users/orphan").set({households: ["h1"]});
+    await migration.up();
+    const data = (await getFirestore().doc("users/orphan").get()).data()!;
+    expect(data.email).toBeNull();
+    expect(data.household_ids).toEqual(["h1"]);
+    expect(data.schema_version).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Implement the migration**
+
+Create `functions/migrations/001-user-shape.ts`:
+
+```ts
+import {getApps, initializeApp} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
+import {getFirestore, FieldValue} from "firebase-admin/firestore";
+import type {Migration} from "./runner";
+
+const BATCH = 400;
+
+const migration: Migration = {
+  id: "001-user-shape",
+  up: async () => {
+    if (getApps().length === 0) initializeApp();
+    const db = getFirestore();
+    const auth = getAuth();
+    let last: FirebaseFirestore.QueryDocumentSnapshot | undefined;
+    while (true) {
+      let q = db.collection("users").orderBy("__name__").limit(BATCH);
+      if (last) q = q.startAfter(last);
+      const snap = await q.get();
+      if (snap.empty) break;
+      const batch = db.batch();
+      for (const doc of snap.docs) {
+        const data = doc.data();
+        if (data.schema_version === 1) continue; // idempotent
+        let email: string | null = data.email ?? null;
+        if (!email) {
+          try { email = (await auth.getUser(doc.id)).email ?? null; } catch { email = null; }
+        }
+        batch.set(doc.ref, {
+          email,
+          display_name: data.display_name ?? null,
+          household_ids: data.household_ids ?? data.households ?? [],
+          current_household_id: data.current_household_id ?? data.current_household ?? null,
+          // Preserve legacy fields untouched (compaction in Phase 6 drops them).
+          households: data.households ?? data.household_ids ?? [],
+          current_household: data.current_household ?? data.current_household_id ?? null,
+          schema_version: 1,
+          created_at: data.created_at ?? FieldValue.serverTimestamp(),
+          updated_at: FieldValue.serverTimestamp(),
+          created_by_uid: data.created_by_uid ?? doc.id,
+        }, {merge: true});
+      }
+      await batch.commit();
+      last = snap.docs[snap.docs.length - 1];
+      if (snap.size < BATCH) break;
+    }
+  },
+};
+
+export default migration;
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/migrations/001-user-shape.test.ts"
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/migrations/001-user-shape.ts functions/test/migrations/001-user-shape.test.ts
+git commit -m "feat(migrations): 001-user-shape backfills new user-doc fields (additive)"
+```
+
+---
+
+## Task 17: Patch v1 `cacheJoinHousehold` / `cacheLeaveHousehold` to dual-write
+
+**Files:**
+- Modify: `functions/src/index.ts`
+- Test: extend the `routes` integration tests OR add a small focused test
+
+The legacy callable-style triggers now write both `households` and `household_ids`. They will be deleted in Phase 2.
+
+- [ ] **Step 1: Edit `functions/src/index.ts`**
+
+In `cacheJoinHousehold` change:
+
+```ts
+.update({
+  households: admin.firestore.FieldValue.arrayUnion(householdId),
+});
+```
+
+to:
+
+```ts
+.update({
+  households: admin.firestore.FieldValue.arrayUnion(householdId),
+  household_ids: admin.firestore.FieldValue.arrayUnion(householdId),
+});
+```
+
+Mirror the same change in `cacheLeaveHousehold`:
+
+```ts
+.update({
+  households: admin.firestore.FieldValue.arrayRemove(householdId),
+  household_ids: admin.firestore.FieldValue.arrayRemove(householdId),
+});
+```
+
+Also add a comment marker so Phase 2 deletes the right block:
+
+```ts
+// PHASE-2-DELETE-START: legacy member-cache triggers (replaced by features/members/)
+exports.cacheJoinHousehold = ...
+exports.cacheLeaveHousehold = ...
+// PHASE-2-DELETE-END
+```
+
+- [ ] **Step 2: Replace v1 setupUser/deleteUser with v2-organised exports**
+
+In the same file, **delete** the existing `exports.setupUser` and `exports.deleteUser` blocks. Replace with:
+
+```ts
+// v2-organised auth lifecycle triggers (impl: features/me/triggers.ts).
+export {onUserCreated, onUserDeleted} from "./features/me/triggers";
+```
+
+- [ ] **Step 3: Build + test**
+
+```bash
+cd functions && npm run build && npm run lint && npm test && cd ..
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/src/index.ts
+git commit -m "feat(triggers): swap setupUser/deleteUser for v2 me triggers; dual-write legacy member triggers"
+```
+
+---
+
+## Task 18: Flutter — delete `lib/data/user.dart`; migrate remaining consumers
+
+**Files:**
+- Delete: `lib/data/user.dart`
+- Modify: `lib/main.dart`
+- Modify: `lib/pages/home.dart`
+- Modify: `lib/pages/list.dart`
+- Modify: `lib/pages/template.dart`
+- Modify: `lib/pages/lists.dart`
+- Modify: `lib/pages/templates.dart`
+- Modify: `lib/pages/household_add.dart`
+- Modify: `lib/layout/drawer.dart`
+- Modify: `lib/data/household.dart`
+
+`FlingUser` and the legacy `StreamProvider<FlingUser?>` go away. All consumers move to `meProvider` / `currentHouseholdIdProvider` / `householdIdsProvider` / `meControllerProvider`.
+
+- [ ] **Step 1: Inventory the consumers**
+
+```bash
+rg "FlingUser|StreamProvider<FlingUser" lib/ -n
+```
+
+Expected list (matches the file map). Confirm none are missed.
+
+- [ ] **Step 2: For each consumer file, do the swap**
+
+The pattern is mechanical:
+
+| Old | New |
+|---|---|
+| `FlingUser? user = Provider.of<FlingUser?>(context)` | `final me = ref.watch(meProvider).valueOrNull;` |
+| `user?.currentHouseholdId` | `ref.watch(currentHouseholdIdProvider)` |
+| `user?.householdIds` | `ref.watch(householdIdsProvider)` |
+| `user?.setCurrentHouseholdId(id)` | `ref.read(meControllerProvider).setCurrentHousehold(id)` |
+| `user?.deleteAccount()` | `await FirebaseAuth.instance.currentUser?.delete()` (the v2 `onUserDeleted` trigger handles the doc cleanup) |
+| `await FlingUser.currentUser.first` | `await ref.read(meProvider.future)` |
+
+Convert `StatelessWidget` → `ConsumerWidget` and `StatefulWidget` → `ConsumerStatefulWidget` as needed.
+
+- [ ] **Step 3: Update `lib/main.dart` to drop the old StreamProvider**
+
+Remove the `provider`-based `StreamProvider<FlingUser?>` block:
+
+```dart
+// remove these:
+import 'package:fling/data/user.dart';
+import 'package:provider/provider.dart';
+
+// inside main():
+Stream<FlingUser?> user = FlingUser.currentUser;
+runApp(ProviderScope(child: MultiProvider(providers: [...], child: const FlingApp())));
+```
+
+Replace with:
+
+```dart
+runApp(const ProviderScope(child: FlingApp()));
+```
+
+If no other code in `main.dart` uses the `provider` package, also remove `provider:` from `pubspec.yaml`'s dependencies (only if no other file imports it — verify with `rg "package:provider/" lib/`).
+
+- [ ] **Step 4: Delete `lib/data/user.dart`**
+
+```bash
+git rm lib/data/user.dart
+```
+
+- [ ] **Step 5: Verify analyse + tests**
+
+```bash
+flutter analyze && flutter test
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib pubspec.yaml pubspec.lock
+git commit -m "refactor(flutter): delete FlingUser; move all consumers to features/me providers"
+```
+
+---
+
+## Task 19: Tighten `firestore.rules` on `/users/{uid}` to owner-only read
+
+**Files:**
+- Modify: `firestore.rules`
+- Modify: `functions/test/rules/baseline.test.ts`
+
+Now that nothing on the client writes to `/users/{uid}` (the v2 trigger creates the doc; PATCH /v1/me updates it), we can flip writes to `false` and reads to owner-only.
+
+- [ ] **Step 1: Edit `firestore.rules`**
+
+Replace the `/users/{uid}` block with:
+
+```text
+match /users/{uid} {
+  allow read:  if signedIn() && request.auth.uid == uid;
+  allow write: if false;
+}
+```
+
+- [ ] **Step 2: Update the rules test**
+
+In `functions/test/rules/baseline.test.ts`, replace the "user can read & write their own /users/{uid} doc" case with:
+
+```ts
+it("user can read but not write their own /users/{uid} doc (writes go through API)", async () => {
+  const alice = env.authenticatedContext("alice").firestore();
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await ctx.firestore().doc("users/alice").set({household_ids: []});
+  });
+  await assertSucceeds(alice.doc("users/alice").get());
+  await assertFails(alice.doc("users/alice").set({household_ids: ["h1"]}));
+});
+```
+
+- [ ] **Step 3: Run the rules test**
+
+```bash
+firebase emulators:exec --only firestore,auth \
+  "cd functions && npx vitest run test/rules"
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firestore.rules functions/test/rules/baseline.test.ts
+git commit -m "feat(rules): tighten /users/{uid} to owner-only read; deny client writes"
+```
+
+---
+
+## Task 20: Slice 3 — open PR, deploy, run migration, smoke
+
+**Files:** none modified.
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+git push
+gh pr create --title "Phase 1 Slice 3 — triggers, migration, rule tighten" --body "$(cat <<'EOF'
+## Summary
+
+Final slice of Phase 1.
+
+- features/me/triggers.ts: v2-organised onUserCreated / onUserDeleted (replaces v1 setupUser/deleteUser)
+- migrations/001-user-shape.ts: idempotent additive backfill of user docs
+- v1 cacheJoinHousehold/cacheLeaveHousehold patched to dual-write `household_ids` until Phase 2 deletes them
+- FlingUser deleted from Flutter; all consumers consume features/me providers
+- firestore.rules: /users/{uid} is owner-only read; no client writes
+
+## Test plan
+- [ ] CI green
+- [ ] After merge: deploy succeeds (`firebase deploy --only functions,firestore:rules`)
+- [ ] Run migration once against prod: `cd functions && GCLOUD_PROJECT=fling-list npm run migrate`
+- [ ] Spot-check 3 users in Firestore: each has `schema_version: 1`, `household_ids`, `current_household_id`, `email`
+- [ ] On a freshly-signed-up user: confirm v2 onUserCreated wrote the new doc shape
+- [ ] On deleting the test user: doc is removed
+- [ ] Direct Firestore write to /users/{uid} from the Flutter app fails with permission-denied
+- [ ] App still works: log in, switch household, view lists, view templates, log out
+EOF
+)"
+```
+
+- [ ] **Step 2: After merge — run the migration in production**
+
+```bash
+cd functions
+GCLOUD_PROJECT=fling-list npm run migrate
+cd ..
+```
+
+Expected: prints `[migrate] apply 001-user-shape` and `[migrate] done 001-user-shape`. Re-running is a no-op.
+
+- [ ] **Step 3: Spot-check 3 user docs in the Firebase console**
+
+Each should have `schema_version: 1`, `household_ids`, `current_household_id`, `email`, `created_at`, `updated_at`, `created_by_uid`. Legacy `households` / `current_household` still present.
+
+- [ ] **Step 4: Production smoke**
+
+In the prod web app:
+1. Log in.
+2. Switch household — UI updates immediately, list re-renders.
+3. View lists, templates — all data loads.
+4. Try a deliberate Firestore-direct write from a debug build (`firestore.collection('users').doc(uid).set(...)`) — confirm `permission-denied`.
+5. Sign up a fresh test user — confirm a `users/{newUid}` doc appears with `schema_version: 1` (v2 trigger fired).
+6. Delete the test user — confirm the `users/{newUid}` doc is gone.
+
+---
+
+## Task 21: Close the phase — STATUS + change log
+
+**Files:**
+- Modify: `docs/superpowers/migrations/STATUS.md`
+
+- [ ] **Step 1: Flip Phase 1 to ✅**
+
+In the Overview table change Phase 1 from `🟡` to `✅`. Set the **Completed** column to today.
+
+- [ ] **Step 2: Tick every box in §"Phase 1 — `me` slice + API foundation"**
+
+Replace each `- [ ]` with `- [x]` for the eight bullets under that heading.
+
+- [ ] **Step 3: Append change-log entries**
+
+```text
+| YYYY-MM-DD | 1 | Slice 1 deployed | <PR-URL> | GET /v1/me + middleware + Flutter feature read path |
+| YYYY-MM-DD | 1 | Slice 2 deployed | <PR-URL> | PATCH /v1/me + idempotency + mutation queue + Flutter writes |
+| YYYY-MM-DD | 1 | Slice 3 deployed | <PR-URL> | v2 triggers, migration #1, rule tighten, FlingUser deleted |
+| YYYY-MM-DD | 1 | Completed        | <PR-URL> | Phase 1 closed; ready for Phase 2 (households + members + invites) |
+```
+
+- [ ] **Step 4: Update "Last updated"** to today.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/migrations/STATUS.md
+git commit -m "docs(rewrite): close Phase 1 (me slice + API foundation)"
+git push
+```
+
+- [ ] **Step 6: Clean up the worktree**
+
+```bash
+cd /Users/garrit/src/garritfra/fling
+git worktree remove .worktrees/phase-1-me-slice
+```
+
+---
+
+## Self-review checklist
+
+- [ ] Every spec exit criterion in STATUS §"Phase 1 — `me` slice + API foundation" maps to at least one task above:
+  - middleware (auth, idempotency, request_id, structured logging, error mapping) → Tasks 1, 2, 3, 4, 8
+  - OpenAPI → Dart client pipeline working end-to-end → Tasks 5, 9 (regen with real Me schemas)
+  - `core/api/mutation_queue.dart` → Task 11
+  - Backend `features/me/` complete (`GET`/`PATCH /v1/me`) → Tasks 5, 9
+  - Flutter `features/me/` migrated; old `FlingUser` deleted → Tasks 6, 12, 13, 18
+  - `setupUser`/`deleteUser` v1 functions replaced by v2 triggers in `features/me/triggers.ts` → Tasks 15, 17
+  - Migration #1 deployed → Tasks 16, 20
+  - Rule tightened: `/users/{uid}` owner-only read → Task 19
+
+- [ ] Every code step is runnable: file paths exact, no `// implement here` placeholders, full code blocks included for non-trivial files.
+
+- [ ] Type names used in later tasks match earlier definitions: `Me`, `PatchMe`, `RequestContext`, `AppError`, `MutationSpec`, `PendingMutation`, `MutationQueue`, `MeRepository`, `MeController`.
+
+- [ ] Cross-phase compatibility encoded:
+  - Backend repo reads both new and legacy field names (Task 5)
+  - Backend writes both new and legacy fields on every patch (Task 5: `patchUserDoc`)
+  - v2 trigger writes both new and legacy fields on user create (Task 5: `createUserDoc`, used from Task 15)
+  - v1 `cacheJoinHousehold`/`cacheLeaveHousehold` dual-write (Task 17)
+  - Migration backfills new fields without dropping legacy (Task 16)
+
+- [ ] Each commit step shows the exact files staged.
+
+- [ ] No deletion of v1 callables that Phase 2 owns (`cacheJoinHousehold`, `cacheLeaveHousehold`, `inviteToHouseholdByEmail`).
+
+- [ ] Each slice ends with a deploy + smoke task; every PR is independently shippable.
+
+- [ ] Rule tighten lands **last** (Task 19), only after all client writes to `/users/{uid}` are gone.
+
+- [ ] Open assumptions worth flagging at exec time:
+  - The `dart-dio` generator's exact method/class names for `PATCH /v1/me` (referenced as `patchV1Me` and `PatchMe` in Task 12) should be verified against the freshly-generated `lib/core/api/generated/lib/src/api/default_api.dart` after Task 9. Adjust call sites if the generator chose different names.
+  - Firestore TTL on `idempotency_keys.expires_at` is enabled out-of-band via `gcloud` after Slice 2 merges (Task 14, Step 2). The middleware functions correctly without it; expired records simply pile up until TTL is enabled.
+  - Trigger SDK choice (`firebase-functions/v1`'s `auth.user()`) is intentional and documented in the plan header.

--- a/firebase.json
+++ b/firebase.json
@@ -37,7 +37,7 @@
     "auth":      { "port": 9099 },
     "functions": { "port": 5001 },
     "firestore": { "port": 8080 },
-    "hosting":   { "port": 5000 },
+    "hosting":   { "port": 5050 },
     "ui":        { "enabled": true, "port": 4000 },
     "singleProjectMode": false
   }

--- a/firebase.json
+++ b/firebase.json
@@ -39,6 +39,6 @@
     "firestore": { "port": 8080 },
     "hosting":   { "port": 5000 },
     "ui":        { "enabled": true, "port": 4000 },
-    "singleProjectMode": true
+    "singleProjectMode": false
   }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-boundaries": "^4.2.2",
         "eslint-plugin-import": "^2.32.0",
         "firebase-functions-test": "^3.4.1",
+        "firebase-tools": "^15.16.0",
         "tsx": "^4.19.2",
         "typescript": "^5.6.3",
         "vitest": "^2.1.9"
@@ -43,6 +44,61 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apphosting/build": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@apphosting/build/-/build-0.1.7.tgz",
+      "integrity": "sha512-zNgQGiAWDOj6c+4ylv5ej3nLGXzMAVmzCGMqlbSarHe4bvBmZ2C5GfBRdJksedP7C9pqlwTWpxU5+GSzhJ+nKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apphosting/common": "^0.0.9",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "colorette": "^2.0.20",
+        "commander": "^11.1.0",
+        "npm-pick-manifest": "^9.0.0",
+        "ts-node": "^10.9.1"
+      },
+      "bin": {
+        "apphosting-local-build": "dist/bin/localbuild.js"
+      }
+    },
+    "node_modules/@apphosting/build/node_modules/@apphosting/common": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@apphosting/common/-/common-0.0.9.tgz",
+      "integrity": "sha512-ZbPZDcVhEN+8m0sf90PmQN4xWaKmmySnBSKKPaIOD0JvcDsRr509WenFEFlojP++VSxwFZDGG/TYsHs1FMMqpw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@apphosting/build/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@apphosting/common": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@apphosting/common/-/common-0.0.8.tgz",
+      "integrity": "sha512-RJu5gXs2HYV7+anxpVPpp04oXeuHbV3qn402AdXVlnuYM/uWo7aceqmngpfp6Bi376UzRqGjfpdwFHxuwsEGXQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@asteasolutions/zod-to-openapi": {
       "version": "7.3.4",
@@ -603,6 +659,70 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz",
+      "integrity": "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite-tools": {
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.21.tgz",
+      "integrity": "sha512-kv8Z7UmmBVECHud63VblgQLp4A+qSklNP7H22VQqFQGrWFTodc73bubcjgmBqThFsIIiEeAEQQYwWGaK2lSDtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.16"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2804,6 +2924,56 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/@google-cloud/cloud-sql-connector": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/cloud-sql-connector/-/cloud-sql-connector-1.10.0.tgz",
+      "integrity": "sha512-PLix9OUaeAfVOKFAqw32/ETvFPef26mcTmDu/iVShGRs+MB1JkL98SwVLHsEjzjfnZrF+BtKqnseoFw0+3LmPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@googleapis/sqladmin": "^35.2.0",
+        "gaxios": "^7.1.4",
+        "google-auth-library": "^10.6.2",
+        "p-throttle": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
@@ -2835,6 +3005,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.0.0.tgz",
+      "integrity": "sha512-9h0Gvw92EvPdE8AK8AgZPbMnH5ftDyPtKm7/KUfcJVaPEPjwGDsJd1QV0H8esBDV4II41R/2lDWH1epBqIoKUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/projectify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
@@ -2853,6 +3033,200 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/pubsub": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-5.3.0.tgz",
+      "integrity": "sha512-hyUoE85Rj3rRUVk3VU+Selp4MorBwEzsQEqAj6+SE+WabR9LIFitYS6A4R+PyiwVaRk/tggGD8p7bNiIY5sk4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^6.0.0",
+        "@google-cloud/precise-date": "^5.0.0",
+        "@google-cloud/projectify": "^5.0.0",
+        "@google-cloud/promisify": "^5.0.0",
+        "@opentelemetry/api": "~1.9.0",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "~1.39.0",
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^10.5.0",
+        "google-gax": "^5.0.5",
+        "heap-js": "^2.6.0",
+        "is-stream-ended": "^0.1.4",
+        "lodash.snakecase": "^4.1.1",
+        "p-defer": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@google-cloud/paginator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.0.tgz",
+      "integrity": "sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@google-cloud/projectify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-5.0.0.tgz",
+      "integrity": "sha512-XXQLaIcLrOAMWvRrzz+mlUGtN6vlVNja3XQbMqRi/V7XJTAVwib3VcKd7oRwyZPkp7rBVlHGcaqdyGRrcnkhlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@google-cloud/promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.0.0.tgz",
+      "integrity": "sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/google-gax": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.6.tgz",
+      "integrity": "sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^10.1.0",
+        "google-logging-utils": "^1.1.1",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^3.0.0",
+        "protobufjs": "^7.5.3",
+        "retry-request": "^8.0.0",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/retry-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/teeny-request": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+      "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/storage": {
@@ -2935,12 +3309,25 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@googleapis/sqladmin": {
+      "version": "35.2.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sqladmin/-/sqladmin-35.2.0.tgz",
+      "integrity": "sha512-ajR9EGLs1pCkKfsXxfbVRnQ7ZPyktKNAuahHoU06CVKguWwQo3b9aFmq06PYnGk1oXc0+tlW+XEamNa/HF4pbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2953,8 +3340,8 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -2985,6 +3372,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@hono/zod-openapi": {
@@ -3083,6 +3483,410 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3128,6 +3932,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -3668,11 +4485,387 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3740,14 +4933,63 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-3.0.0.tgz",
+      "integrity": "sha512-s9SgS+p3a9Eohe68cSI3fi+hpcZUmXq5P7w0kMlAsWVtR7XbK3ptkZqKT2cK1zLDObJ3sR+8P59sJE0w/KTL1g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "infer-owner": "^1.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3773,6 +5015,51 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -4204,6 +5491,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -4226,6 +5526,17 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -4235,6 +5546,41 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -4399,6 +5745,13 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -4520,6 +5873,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -5229,12 +6589,23 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -5278,6 +6649,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -5302,6 +6686,80 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-escapes": {
@@ -5361,13 +6819,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -5382,13 +6846,141 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5529,11 +7121,18 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/as-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/as-array/-/as-array-2.0.0.tgz",
+      "integrity": "sha512-1Sd1LrodN0XYxYeZcN1J4xYZvmvTwD5tDWaPUGPIzH1mFsmzsPnVtd2exWhecMjtZk/wYWjNZJiD3b1SLCeJqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -5545,6 +7144,26 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5554,6 +7173,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -5569,8 +7195,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -5586,6 +7212,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -5702,6 +7343,103 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5736,6 +7474,46 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth-connect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.1.0.tgz",
+      "integrity": "sha512-rKcWjfiRZ3p5WS9e5q6msXa07s6DaFAMXoyowV+mb2xQG+oYdw2QEUyKi0Xp95JvXzShlM+oGy5QuqSK6TfC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "^1.0.6"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -5743,6 +7521,31 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -5783,6 +7586,82 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
@@ -5854,6 +7733,41 @@
       "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -5936,6 +7850,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -6020,10 +7941,16 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/check-error": {
       "version": "2.1.3",
@@ -6033,6 +7960,54 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -6059,6 +8034,209 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/cjson": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.3.tgz",
+      "integrity": "sha512-yKNcXi/Mvi5kb1uK0sahubYiyfUO2EUgOp4NcY9+8NX5Xmc+4yeNogZuLFkpLBBj7/QI9MjRUIuXrV9XOw5kVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-parse-helpfulerror": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.3.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-highlight/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -6115,6 +8293,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6134,6 +8322,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6155,17 +8357,198 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -6174,6 +8557,173 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/configstore/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/configstore/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/configstore/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/configstore/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/connect/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/connect/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -6219,6 +8769,13 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -6236,6 +8793,101 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6250,6 +8902,23 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -6357,6 +9026,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal-in-any-order": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-2.2.0.tgz",
+      "integrity": "sha512-lUYf3Oz/HrPcNmKe+S+QSdY5/hzKleftcFBWLwbHNZ5007RUKgN0asWlAHuQGvT9djYd9PYQFiu0TyNS+h3j/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-any": "^4.0.0"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==",
+      "dev": true,
+      "license": "public domain"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6373,6 +9069,19 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-data-property": {
@@ -6411,12 +9120,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6451,6 +9175,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -6462,6 +9203,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -6482,8 +9236,8 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -6542,6 +9296,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -6555,10 +9323,34 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -6777,6 +9569,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -6794,6 +9596,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -7190,7 +10014,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -7268,10 +10091,60 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-listener": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/events-listener/-/events-listener-1.1.0.tgz",
+      "integrity": "sha512-Kd3EgYfODHueq6GzVfs/VUolh2EgJsS8hkO3KpnDrxVjU3eq63eXM2ujXkhPP+OkeUOhL8CxdfZbQXzryb5C4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -7306,6 +10179,101 @@
       "dev": true,
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/exegesis": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/exegesis/-/exegesis-4.3.0.tgz",
+      "integrity": "sha512-V90IJQ4XYO1SfH5qdJTOijXkQTF3hSpSHHqlf7MstUMDKP22iAvi63gweFLtPZ4Gj3Wnh8RgJX5TGu0WiwTyDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.3",
+        "ajv": "^8.3.0",
+        "ajv-formats": "^2.1.0",
+        "body-parser": "^1.18.3",
+        "content-type": "^1.0.4",
+        "deep-freeze": "0.0.1",
+        "events-listener": "^1.1.0",
+        "glob": "^10.3.10",
+        "json-ptr": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "lodash": "^4.17.11",
+        "openapi3-ts": "^3.1.1",
+        "promise-breaker": "^6.0.0",
+        "qs": "^6.6.0",
+        "raw-body": "^2.3.3",
+        "semver": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">5.0.0"
+      }
+    },
+    "node_modules/exegesis-express": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/exegesis-express/-/exegesis-express-4.0.0.tgz",
+      "integrity": "sha512-V2hqwTtYRj0bj43K4MCtm0caD97YWkqOUHFMRCBW5L1x9IjyqOEc7Xa4oQjjiFbeFOSQzzwPV+BzXsQjSz08fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "exegesis": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">5.0.0"
+      }
+    },
+    "node_modules/exegesis/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/exegesis/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/exegesis/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exegesis/node_modules/openapi3-ts": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
+      "integrity": "sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.1"
+      }
     },
     "node_modules/exit-x": {
       "version": "0.2.2",
@@ -7346,6 +10314,14 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/express": {
       "version": "4.22.1",
@@ -7393,6 +10369,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7429,6 +10424,13 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -7442,6 +10444,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.5",
@@ -7532,6 +10551,13 @@
         }
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -7566,6 +10592,16 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
+      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/fill-range": {
@@ -7736,6 +10772,260 @@
         "jest": ">=28.0.0"
       }
     },
+    "node_modules/firebase-tools": {
+      "version": "15.16.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.16.0.tgz",
+      "integrity": "sha512-+x0AK8IXQFnyOsiVxcm/wHCxqi0Yj9iD659rZum91uxoayn23h6kX4CFL9dVqVkodh43luzilKh2iyfXU6QgFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apphosting/build": "^0.1.7",
+        "@apphosting/common": "^0.0.8",
+        "@electric-sql/pglite": "^0.3.3",
+        "@electric-sql/pglite-tools": "^0.2.8",
+        "@google-cloud/cloud-sql-connector": "^1.3.3",
+        "@google-cloud/pubsub": "^5.2.0",
+        "@inquirer/prompts": "^7.10.1",
+        "@modelcontextprotocol/sdk": "^1.24.0",
+        "abort-controller": "^3.0.0",
+        "ajv": "^8.17.1",
+        "ajv-formats": "3.0.1",
+        "archiver": "^7.0.0",
+        "async-lock": "1.4.1",
+        "body-parser": "^1.19.0",
+        "chokidar": "^3.6.0",
+        "cjson": "^0.3.1",
+        "cli-table3": "0.6.5",
+        "colorette": "^2.0.19",
+        "commander": "^5.1.0",
+        "configstore": "^5.0.1",
+        "cors": "^2.8.5",
+        "cross-env": "^7.0.3",
+        "cross-spawn": "^7.0.5",
+        "csv-parse": "^5.0.4",
+        "deep-equal-in-any-order": "^2.0.6",
+        "exegesis": "^4.2.0",
+        "exegesis-express": "^4.0.0",
+        "express": "^4.16.4",
+        "filesize": "^6.1.0",
+        "form-data": "^4.0.1",
+        "fs-extra": "^10.1.0",
+        "fuzzy": "^0.1.3",
+        "gaxios": "^6.7.0",
+        "glob": "^10.5.0",
+        "google-auth-library": "^9.11.0",
+        "ignore": "^7.0.4",
+        "js-yaml": "^3.14.2",
+        "jsonwebtoken": "^9.0.2",
+        "leven": "^3.1.0",
+        "libsodium-wrappers": "^0.7.10",
+        "lodash": "^4.18.0",
+        "lsofi": "^2.0.0",
+        "marked": "^13.0.2",
+        "marked-terminal": "^7.0.0",
+        "mime": "^2.5.2",
+        "minimatch": "^3.0.4",
+        "morgan": "^1.10.0",
+        "node-fetch": "^2.6.7",
+        "open": "^6.3.0",
+        "ora": "^5.4.1",
+        "p-limit": "^3.0.1",
+        "pg": "^8.11.3",
+        "pg-gateway": "^0.3.0-beta.4",
+        "pglite-2": "npm:@electric-sql/pglite@0.2.17",
+        "portfinder": "^1.0.32",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.3.0",
+        "retry": "^0.13.1",
+        "semver": "^7.5.2",
+        "sql-formatter": "^15.3.0",
+        "stream-chain": "^2.2.4",
+        "stream-json": "^1.7.3",
+        "superstatic": "^10.0.0",
+        "tar": "^7.5.11",
+        "tcp-port-used": "^1.0.2",
+        "tmp": "^0.2.3",
+        "triple-beam": "^1.3.0",
+        "universal-analytics": "^0.5.3",
+        "update-notifier-cjs": "^5.1.6",
+        "uuid": "^8.3.2",
+        "winston": "^3.0.0",
+        "winston-transport": "^4.4.0",
+        "ws": "^7.5.10",
+        "yaml": "^2.8.3",
+        "zod": "^3.24.3",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "bin": {
+        "firebase": "lib/bin/firebase.js"
+      },
+      "engines": {
+        "node": ">=20.0.0 || >=22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/firebase-tools/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/firebase-tools/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/firebase/node_modules/@firebase/app-types": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
@@ -7861,6 +11151,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7942,6 +11239,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8011,12 +11323,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fuzzy": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
+      "integrity": "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/gaxios": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -8032,12 +11353,12 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8212,6 +11533,31 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -8247,6 +11593,25 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glob-slash/-/glob-slash-1.0.0.tgz",
+      "integrity": "sha512-ZwFh34WZhZX28ntCMAP1mwyAJkn8+Omagvt/GvA+JQM/qgT0+MR2NPF3vhvgdshfdvDyGZXs8fPXW84K32Wjuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob-slasher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glob-slasher/-/glob-slasher-1.0.1.tgz",
+      "integrity": "sha512-5MUzqFiycIKLMD1B0dYOE4hGgLLUZUNGGYO4BExdwT32wUwW3DBOE7lMQars7vB1q43Fb3Tyt+HmgLKsJhDYdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-slash": "^1.0.0",
+        "lodash.isobject": "^2.4.1",
+        "toxic": "^1.0.0"
+      }
+    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -8278,6 +11643,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-dirs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globals": {
@@ -8452,6 +11833,57 @@
         "node": ">=14"
       }
     },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -8469,8 +11901,7 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -8483,8 +11914,8 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -8573,6 +12004,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -8585,6 +12026,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/heap-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.7.1.tgz",
+      "integrity": "sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/hono": {
       "version": "4.12.15",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
@@ -8593,6 +12054,26 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/html-entities": {
       "version": "2.6.0",
@@ -8716,6 +12197,27 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -8741,6 +12243,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/import-local": {
@@ -8774,6 +12286,13 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -8792,6 +12311,31 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/install-artifact-from-github": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.6.0.tgz",
+      "integrity": "sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "bin": {
+        "install-from-cache": "bin/install-from-cache.js",
+        "save-to-github-cache": "bin/save-to-github-cache.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -8805,6 +12349,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ipaddr.js": {
@@ -8878,6 +12442,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
@@ -8907,6 +12484,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-ci/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -9039,6 +12636,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -9063,6 +12687,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -9092,6 +12729,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -9101,6 +12748,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -9163,6 +12817,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -9214,6 +12875,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -9260,6 +12948,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is2": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
+      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "ip-regex": "^4.1.0",
+        "is-url": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=v0.10.0"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -9273,6 +12993,17 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -9968,6 +13699,25 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/join-path": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/join-path/-/join-path-1.1.1.tgz",
+      "integrity": "sha512-jnt9OC34sLXMLJ6YfPQ2ZEKrR9mB5ZbSnQb4LPaOx1c5rTzxpR33L18jjp0r75mGGTJmsil3qwN1B5IBeTnSSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "as-array": "^2.0.0",
+        "url-join": "0.0.1",
+        "valid-url": "^1"
+      }
+    },
     "node_modules/jose": {
       "version": "4.15.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
@@ -10036,12 +13786,37 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha512-XgP0FGR77+QhUxjXkwOMkC94k3WtqEBfcnjWqhRd82qTat4SWKRE+9kUnynz/shm3I4ea2+qISvTIeGTNU7kJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "^1.1.0"
+      }
+    },
+    "node_modules/json-ptr": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-ptr/-/json-ptr-3.1.1.tgz",
+      "integrity": "sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10062,6 +13837,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -10133,13 +13921,72 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10156,6 +14003,23 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.16.tgz",
+      "integrity": "sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.16.tgz",
+      "integrity": "sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.7.16"
       }
     },
     "node_modules/limiter": {
@@ -10191,6 +14055,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -10231,6 +14102,16 @@
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
       "license": "MIT"
     },
+    "node_modules/lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -10255,6 +14136,58 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -10308,6 +14241,16 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
+    "node_modules/lsofi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lsofi/-/lsofi-2.0.0.tgz",
+      "integrity": "sha512-XTFlOBHeuXnUGuUQI0kBb4O4oQW7qCV7MRGQja1xNpxgrI/jptlly+/5126RiRold1zgyxY520qOZUZ31V0I2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -10346,6 +14289,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -10355,6 +14305,83 @@
       "peer": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
+      "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -10468,7 +14495,6 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10509,11 +14535,108 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -10558,6 +14681,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -10565,6 +14718,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-domexception": {
@@ -10585,6 +14748,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/node-exports-info": {
@@ -10620,8 +14799,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -10646,6 +14825,71 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-gyp": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
+      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10662,15 +14906,86 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-install-checks": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
+      "integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
+      "integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^4.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
+      "integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^6.0.0",
+        "npm-normalize-package-bin": "^3.0.0",
+        "npm-package-arg": "^11.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -10700,8 +15015,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10830,6 +15145,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10840,13 +15165,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -10855,6 +15189,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/openapi3-ts": {
@@ -10884,6 +15231,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -10900,6 +15271,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -10934,6 +15315,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-throttle": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-7.0.0.tgz",
+      "integrity": "sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -10943,6 +15337,54 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -10984,6 +15426,30 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -11094,6 +15560,118 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-gateway": {
+      "version": "0.3.0-beta.4",
+      "resolved": "https://registry.npmjs.org/pg-gateway/-/pg-gateway-0.3.0-beta.4.tgz",
+      "integrity": "sha512-CTjsM7Z+0Nx2/dyZ6r8zRsc3f9FScoD5UAOlfUx1Fdv/JOIWvRbF7gou6l6vP+uypXQVoYPgw8xZDXgMGvBa4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pglite-2": {
+      "name": "@electric-sql/pglite",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.17.tgz",
+      "integrity": "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11123,6 +15701,16 @@
       "peer": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -11199,6 +15787,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11236,6 +15838,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -11277,6 +15922,57 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-breaker": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/promise-breaker/-/promise-breaker-6.0.0.tgz",
+      "integrity": "sha512-BthzO9yTPswGf7etOBiHCVuugs2N01/Q/94dIPls48z2zCmrnDptUUZzfIb+41xq0MnYZ/BzmOd6ikDR4ibNZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
@@ -11328,6 +16024,57 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11336,6 +16083,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pure-rand": {
@@ -11392,6 +16152,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -11416,6 +16197,56 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/re2": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.24.0.tgz",
+      "integrity": "sha512-pBm6cMaOb0Yb0kg0Sfw/k4LwDMkPScb/NVd7GrEllDwfsPZstsZIo93A6Nn0wZuWJw3h57GdzkrOk81EofKY/g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "install-artifact-from-github": "^1.4.0",
+        "nan": "^2.26.2",
+        "node-gyp": "^12.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -11428,8 +16259,8 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -11437,6 +16268,72 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11483,11 +16380,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11562,12 +16495,43 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -11713,6 +16677,34 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11812,6 +16804,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -11828,6 +16830,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/send": {
@@ -12066,6 +17091,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12077,13 +17115,73 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks/node_modules/ip-address": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/sort-any": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-4.0.7.tgz",
+      "integrity": "sha512-UuZVEXClHW+bVa6ZBQ4biTWmLXMP7y6/jv5arfA0rKk7ZExy+5Zm19uekIqqDx6ZuvUMu7z5Ba9FfBi6FlGXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12110,13 +17208,46 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.7.3.tgz",
+      "integrity": "sha512-5+zl9Nqg5aNjss0tb1G+StpC4dJKbjv3+g8CL/+V+00PfZop+2RKGyi53ScFl0dr+Dkx1LjmUO54Q3N7K3EtMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -12180,29 +17311,58 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stream-events": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
       }
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -12430,8 +17590,103 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/superstatic": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-10.0.0.tgz",
+      "integrity": "sha512-4xIenBdrIIYuqXrIVx/lejyCh4EJwEMPCwfk9VGFfRlhZcdvzTd3oVOUILrAGfC4pFUWixzPgaOVzAEZgeYI3w==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "basic-auth-connect": "^1.1.0",
+        "commander": "^10.0.0",
+        "compression": "^1.7.0",
+        "connect": "^3.7.0",
+        "destroy": "^1.0.4",
+        "glob-slasher": "^1.0.1",
+        "is-url": "^1.2.2",
+        "join-path": "^1.1.1",
+        "lodash": "^4.17.19",
+        "mime-types": "^2.1.35",
+        "minimatch": "^6.1.6",
+        "morgan": "^1.8.2",
+        "on-finished": "^2.2.0",
+        "on-headers": "^1.0.0",
+        "path-to-regexp": "^1.9.0",
+        "router": "^2.0.0",
+        "update-notifier-cjs": "^5.1.6"
+      },
+      "bin": {
+        "superstatic": "lib/bin/server.js"
+      },
+      "engines": {
+        "node": "20 || 22 || 24"
+      },
+      "optionalDependencies": {
+        "re2": "^1.17.7"
+      }
+    },
+    "node_modules/superstatic/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superstatic/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/superstatic/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/superstatic/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superstatic/node_modules/minimatch": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.3.tgz",
+      "integrity": "sha512-5rvZbDy5y2k40rre/0OBbYnl03en25XPU3gOVO7532beGMjAipq88VdS9OeLOZNrD+Tb0lDhBJHZ7Gcd8qKlPg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/superstatic/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -12444,6 +17699,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -12475,6 +17747,82 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tcp-port-used": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
+      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.3.1",
+        "is2": "^2.0.6"
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/teeny-request": {
       "version": "9.0.0",
@@ -12532,6 +17880,16 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/test-exclude": {
@@ -12607,12 +17965,52 @@
         "node": "*"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -12675,6 +18073,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -12705,12 +18113,32 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toxic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toxic/-/toxic-1.0.1.tgz",
+      "integrity": "sha512-WI3rIGdcaKULYg7KVoB0zcjikqvcYYvcuT6D89bFPz2rVR0Rl0PK6x8/X62rtdLtBKIE985NzVf/auTtGegIIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.10"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -12731,6 +18159,50 @@
       "integrity": "sha512-3phiGcxPSSR47RBubQxPoZ+pqXsEsozLo4G4AlSrsMKTFg9TA3l+3he5BqpUi9wiuDbaHWXH/amlzQ49uEdXtg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -12773,6 +18245,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -12922,6 +18404,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -12955,11 +18447,80 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universal-analytics": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.5.3.tgz",
+      "integrity": "sha512-HXSMyIcf2XTvwZ6ZZQLfxfViRm/yTGoRgDeTbojtq6rezeyKB0sTBcKH2fhddnteAHRcHiKgr/ACpbgjGOC6RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.18.2"
+      }
+    },
+    "node_modules/universal-analytics/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -13038,6 +18599,34 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/update-notifier-cjs": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/update-notifier-cjs/-/update-notifier-cjs-5.1.7.tgz",
+      "integrity": "sha512-eZWTh8F+VCEoC4UIh0pKmh8h4izj65VvLhCpJpVefUxdYe0fU3GBrC4Sbh1AoWA/miNPAb6UVlp2fUQNsfp+3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
+        "is-yarn-global": "^0.3.0",
+        "isomorphic-fetch": "^3.0.0",
+        "pupa": "^2.1.1",
+        "registry-auth-token": "^5.0.1",
+        "registry-url": "^5.1.0",
+        "semver": "^7.3.7",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -13048,12 +18637,26 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -13077,6 +18680,13 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -13091,6 +18701,22 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/vary": {
@@ -13692,6 +19318,16 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -13713,8 +19349,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -13739,12 +19375,19 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -13870,6 +19513,89 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/word-wrap": {
@@ -14005,6 +19731,48 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -14089,6 +19857,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -14102,6 +19880,76 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -14109,6 +19957,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/functions/package.json
+++ b/functions/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-boundaries": "^4.2.2",
     "eslint-plugin-import": "^2.32.0",
     "firebase-functions-test": "^3.4.1",
+    "firebase-tools": "^15.16.0",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
     "vitest": "^2.1.9"

--- a/functions/src/api/app.ts
+++ b/functions/src/api/app.ts
@@ -1,4 +1,7 @@
 import {OpenAPIHono, createRoute, z} from "@hono/zod-openapi";
+import {requestIdMiddleware, authMiddleware} from "../core/middleware";
+import {installErrorHandler} from "../core/errors";
+import {registerMeRoutes} from "../features/me/module";
 
 const HealthSchema = z.object({
   status: z.literal("ok"),
@@ -9,18 +12,23 @@ const healthzRoute = createRoute({
   method: "get",
   path: "/v1/healthz",
   responses: {
-    200: {
-      description: "Health check",
-      content: {"application/json": {schema: HealthSchema}},
-    },
+    200: {description: "Health check", content: {"application/json": {schema: HealthSchema}}},
   },
 });
 
 export const app = new OpenAPIHono();
 
+installErrorHandler(app);
+app.use("*", requestIdMiddleware());
+
+// Public endpoints (no auth) come before the auth middleware mount.
 app.openapi(healthzRoute, (c) =>
   c.json({status: "ok" as const, version: process.env.K_REVISION ?? "dev"}),
 );
+
+// Authenticated /v1/* routes.
+app.use("/v1/*", authMiddleware());
+registerMeRoutes(app);
 
 app.doc("/v1/openapi.json", {
   openapi: "3.0.3",

--- a/functions/src/api/app.ts
+++ b/functions/src/api/app.ts
@@ -21,16 +21,16 @@ export const app = new OpenAPIHono();
 installErrorHandler(app);
 app.use("*", requestIdMiddleware());
 
-// Public endpoints (no auth) come before the auth middleware mount.
+// Public endpoints — registered before the auth middleware so they are accessible without a token.
 app.openapi(healthzRoute, (c) =>
   c.json({status: "ok" as const, version: process.env.K_REVISION ?? "dev"}),
 );
-
-// Authenticated /v1/* routes.
-app.use("/v1/*", authMiddleware());
-registerMeRoutes(app);
 
 app.doc("/v1/openapi.json", {
   openapi: "3.0.3",
   info: {title: "Fling API", version: "1.0.0"},
 });
+
+// Authenticated /v1/* routes — auth middleware applies to everything registered after this point.
+app.use("/v1/*", authMiddleware());
+registerMeRoutes(app);

--- a/functions/src/core/auth/index.ts
+++ b/functions/src/core/auth/index.ts
@@ -1,3 +1,1 @@
-// core/auth: populated in Phase 1+.
-// See docs/superpowers/specs/2026-04-24-fling-rewrite-design.md §5.
-export {};
+export {authMiddleware} from "../middleware/auth";

--- a/functions/src/core/context/index.ts
+++ b/functions/src/core/context/index.ts
@@ -1,3 +1,2 @@
-// core/context: populated in Phase 1+.
-// See docs/superpowers/specs/2026-04-24-fling-rewrite-design.md §5.
-export {};
+export type {RequestContext} from "./request_context";
+export {getRequestContext, setRequestContext} from "./request_context";

--- a/functions/src/core/context/request_context.ts
+++ b/functions/src/core/context/request_context.ts
@@ -1,0 +1,20 @@
+import type {Context} from "hono";
+
+export interface RequestContext {
+  uid: string;
+  email?: string;
+  requestId: string;
+  householdId?: string;
+}
+
+const KEY = "__fling_request_context";
+
+export function setRequestContext(c: Context, ctx: RequestContext): void {
+  c.set(KEY, ctx);
+}
+
+export function getRequestContext(c: Context): RequestContext {
+  const ctx = c.get(KEY) as RequestContext | undefined;
+  if (!ctx) throw new Error("RequestContext missing — middleware not mounted");
+  return ctx;
+}

--- a/functions/src/core/errors/app_error.ts
+++ b/functions/src/core/errors/app_error.ts
@@ -1,0 +1,41 @@
+export class AppError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly status: number,
+    public readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+export class BadRequest extends AppError {
+  constructor(message = "Bad request", details?: Record<string, unknown>) {
+    super("BAD_REQUEST", message, 400, details);
+  }
+}
+
+export class Unauthorized extends AppError {
+  constructor(message = "Unauthorized") {
+    super("UNAUTHORIZED", message, 401);
+  }
+}
+
+export class Forbidden extends AppError {
+  constructor(message = "Forbidden") {
+    super("FORBIDDEN", message, 403);
+  }
+}
+
+export class NotFound extends AppError {
+  constructor(message = "Not found") {
+    super("NOT_FOUND", message, 404);
+  }
+}
+
+export class Conflict extends AppError {
+  constructor(message = "Conflict", details?: Record<string, unknown>) {
+    super("CONFLICT", message, 409, details);
+  }
+}

--- a/functions/src/core/errors/handler.ts
+++ b/functions/src/core/errors/handler.ts
@@ -8,7 +8,8 @@ export function installErrorHandler(app: Hono | OpenAPIHono): void {
   app.onError((err, c) => {
     if (err instanceof ZodError) {
       const wrapped = new BadRequest("Validation failed", {issues: err.issues});
-      return c.json({error: {code: wrapped.code, message: wrapped.message, details: wrapped.details}}, 400);
+      const {code, message, details} = wrapped;
+      return c.json({error: {code, message, details}}, 400);
     }
     if (err instanceof AppError) {
       const body: {error: {code: string; message: string; details?: Record<string, unknown>}} = {

--- a/functions/src/core/errors/handler.ts
+++ b/functions/src/core/errors/handler.ts
@@ -1,0 +1,23 @@
+import type {Hono} from "hono";
+import type {OpenAPIHono} from "@hono/zod-openapi";
+import {ZodError} from "zod";
+import {AppError, BadRequest} from "./app_error";
+import {logger} from "../logger";
+
+export function installErrorHandler(app: Hono | OpenAPIHono): void {
+  app.onError((err, c) => {
+    if (err instanceof ZodError) {
+      const wrapped = new BadRequest("Validation failed", {issues: err.issues});
+      return c.json({error: {code: wrapped.code, message: wrapped.message, details: wrapped.details}}, 400);
+    }
+    if (err instanceof AppError) {
+      const body: {error: {code: string; message: string; details?: Record<string, unknown>}} = {
+        error: {code: err.code, message: err.message},
+      };
+      if (err.details) body.error.details = err.details;
+      return c.json(body, err.status as 400 | 401 | 403 | 404 | 409 | 418);
+    }
+    logger.error("Unhandled error", {message: err.message, stack: err.stack});
+    return c.json({error: {code: "INTERNAL", message: "Internal server error"}}, 500);
+  });
+}

--- a/functions/src/core/errors/index.ts
+++ b/functions/src/core/errors/index.ts
@@ -1,3 +1,2 @@
-// core/errors: populated in Phase 1+.
-// See docs/superpowers/specs/2026-04-24-fling-rewrite-design.md §5.
-export {};
+export * from "./app_error";
+export {installErrorHandler} from "./handler";

--- a/functions/src/core/logger/index.ts
+++ b/functions/src/core/logger/index.ts
@@ -1,3 +1,2 @@
-// core/logger: populated in Phase 1+.
-// See docs/superpowers/specs/2026-04-24-fling-rewrite-design.md §5.
-export {};
+export {logger, withRequestContext} from "./logger";
+export type {Logger} from "./logger";

--- a/functions/src/core/logger/logger.ts
+++ b/functions/src/core/logger/logger.ts
@@ -1,0 +1,29 @@
+import type {RequestContext} from "../context/request_context";
+
+export interface Logger {
+  info(msg: string, fields?: Record<string, unknown>): void;
+  warn(msg: string, fields?: Record<string, unknown>): void;
+  error(msg: string, fields?: Record<string, unknown>): void;
+}
+
+function emit(level: "INFO" | "WARN" | "ERROR", msg: string, fields?: Record<string, unknown>): void {
+  const line = JSON.stringify({severity: level, message: msg, ...fields});
+  if (level === "ERROR") console.error(line);
+  else if (level === "WARN") console.warn(line);
+  else console.log(line);
+}
+
+export const logger: Logger = {
+  info: (m, f) => emit("INFO", m, f),
+  warn: (m, f) => emit("WARN", m, f),
+  error: (m, f) => emit("ERROR", m, f),
+};
+
+export function withRequestContext(ctx: RequestContext): Logger {
+  const base = {request_id: ctx.requestId, uid: ctx.uid};
+  return {
+    info: (m, f) => emit("INFO", m, {...base, ...f}),
+    warn: (m, f) => emit("WARN", m, {...base, ...f}),
+    error: (m, f) => emit("ERROR", m, {...base, ...f}),
+  };
+}

--- a/functions/src/core/logger/logger.ts
+++ b/functions/src/core/logger/logger.ts
@@ -6,7 +6,8 @@ export interface Logger {
   error(msg: string, fields?: Record<string, unknown>): void;
 }
 
-function emit(level: "INFO" | "WARN" | "ERROR", msg: string, fields?: Record<string, unknown>): void {
+type Level = "INFO" | "WARN" | "ERROR";
+function emit(level: Level, msg: string, fields?: Record<string, unknown>): void {
   const line = JSON.stringify({severity: level, message: msg, ...fields});
   if (level === "ERROR") console.error(line);
   else if (level === "WARN") console.warn(line);

--- a/functions/src/core/middleware/auth.ts
+++ b/functions/src/core/middleware/auth.ts
@@ -1,0 +1,27 @@
+import type {MiddlewareHandler} from "hono";
+import {Unauthorized} from "../errors/app_error";
+import {setRequestContext} from "../context/request_context";
+import {getApps, initializeApp} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
+
+function ensureAdmin() {
+  if (getApps().length === 0) initializeApp();
+}
+
+export function authMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    ensureAdmin();
+    const header = c.req.header("authorization") ?? "";
+    const m = /^Bearer\s+(.+)$/.exec(header);
+    if (!m) throw new Unauthorized("Missing or malformed Authorization header");
+    let decoded;
+    try {
+      decoded = await getAuth().verifyIdToken(m[1]);
+    } catch {
+      throw new Unauthorized("Invalid token");
+    }
+    const requestId = (c.get("requestId") as string | undefined) ?? "";
+    setRequestContext(c, {uid: decoded.uid, email: decoded.email, requestId});
+    await next();
+  };
+}

--- a/functions/src/core/middleware/index.ts
+++ b/functions/src/core/middleware/index.ts
@@ -1,1 +1,2 @@
 export {requestIdMiddleware} from "./request_id";
+export {authMiddleware} from "./auth";

--- a/functions/src/core/middleware/index.ts
+++ b/functions/src/core/middleware/index.ts
@@ -1,3 +1,1 @@
-// core/middleware: populated in Phase 1+.
-// See docs/superpowers/specs/2026-04-24-fling-rewrite-design.md §5.
-export {};
+export {requestIdMiddleware} from "./request_id";

--- a/functions/src/core/middleware/request_id.ts
+++ b/functions/src/core/middleware/request_id.ts
@@ -7,9 +7,10 @@ const SAFE_RID = /^[A-Za-z0-9._\-:]+$/;
 export function requestIdMiddleware(): MiddlewareHandler {
   return async (c, next) => {
     const incoming = c.req.header("x-request-id");
-    const rid = incoming && incoming.length <= MAX_INCOMING_LEN && SAFE_RID.test(incoming)
-      ? incoming
-      : randomUUID();
+    const rid =
+      incoming && incoming.length <= MAX_INCOMING_LEN && SAFE_RID.test(incoming) ?
+        incoming :
+        randomUUID();
     c.set("requestId", rid);
     c.header("x-request-id", rid);
     await next();

--- a/functions/src/core/middleware/request_id.ts
+++ b/functions/src/core/middleware/request_id.ts
@@ -1,0 +1,17 @@
+import type {MiddlewareHandler} from "hono";
+import {randomUUID} from "node:crypto";
+
+const MAX_INCOMING_LEN = 128;
+const SAFE_RID = /^[A-Za-z0-9._\-:]+$/;
+
+export function requestIdMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const incoming = c.req.header("x-request-id");
+    const rid = incoming && incoming.length <= MAX_INCOMING_LEN && SAFE_RID.test(incoming)
+      ? incoming
+      : randomUUID();
+    c.set("requestId", rid);
+    c.header("x-request-id", rid);
+    await next();
+  };
+}

--- a/functions/src/features/me/events.ts
+++ b/functions/src/features/me/events.ts
@@ -1,0 +1,3 @@
+// features/me/events: populated in Phase 5 (events bus).
+// Domain events emitted: `me.created.v1`, `me.deleted.v1`, `me.updated.v1`.
+export {};

--- a/functions/src/features/me/module.ts
+++ b/functions/src/features/me/module.ts
@@ -1,3 +1,2 @@
-// features/me: populated in the corresponding phase.
-// See docs/superpowers/specs/2026-04-24-fling-rewrite-design.md §5.
 export const FEATURE_NAME = "me" as const;
+export {registerMeRoutes} from "./routes";

--- a/functions/src/features/me/repo.ts
+++ b/functions/src/features/me/repo.ts
@@ -1,0 +1,68 @@
+import {getApps, initializeApp} from "firebase-admin/app";
+import {getFirestore, FieldValue} from "firebase-admin/firestore";
+import type {Me} from "./schemas";
+
+function db() {
+  if (getApps().length === 0) initializeApp();
+  return getFirestore();
+}
+
+interface RawUserDoc {
+  email?: string;
+  display_name?: string;
+  household_ids?: string[];
+  current_household_id?: string;
+  // legacy field names — read for backwards compatibility until Phase 6
+  households?: string[];
+  current_household?: string;
+}
+
+export async function readUserDoc(uid: string): Promise<Me | null> {
+  const snap = await db().collection("users").doc(uid).get();
+  if (!snap.exists) return null;
+  const raw = snap.data() as RawUserDoc;
+  return {
+    uid,
+    email: raw.email ?? null,
+    displayName: raw.display_name ?? null,
+    householdIds: raw.household_ids ?? raw.households ?? [],
+    currentHouseholdId: raw.current_household_id ?? raw.current_household ?? null,
+  };
+}
+
+export async function patchUserDoc(uid: string, patch: {
+  currentHouseholdId?: string;
+  displayName?: string;
+}): Promise<void> {
+  const update: Record<string, unknown> = {
+    updated_at: FieldValue.serverTimestamp(),
+  };
+  if (patch.currentHouseholdId !== undefined) {
+    update.current_household_id = patch.currentHouseholdId;
+    // Dual-write the legacy field while Flutter clients still read it.
+    update.current_household = patch.currentHouseholdId;
+  }
+  if (patch.displayName !== undefined) {
+    update.display_name = patch.displayName;
+  }
+  await db().collection("users").doc(uid).set(update, {merge: true});
+}
+
+export async function createUserDoc(uid: string, email: string | null): Promise<void> {
+  await db().collection("users").doc(uid).set({
+    email: email ?? null,
+    display_name: null,
+    household_ids: [],
+    current_household_id: null,
+    households: [],            // legacy, dual-write
+    current_household: null,   // legacy, dual-write
+    schema_version: 1,
+    created_at: FieldValue.serverTimestamp(),
+    updated_at: FieldValue.serverTimestamp(),
+    created_by_uid: uid,
+  }, {merge: true});
+}
+
+export async function deleteUserDoc(uid: string): Promise<void> {
+  await db().collection("users").doc(uid).delete();
+}

--- a/functions/src/features/me/repo.ts
+++ b/functions/src/features/me/repo.ts
@@ -54,8 +54,8 @@ export async function createUserDoc(uid: string, email: string | null): Promise<
     display_name: null,
     household_ids: [],
     current_household_id: null,
-    households: [],            // legacy, dual-write
-    current_household: null,   // legacy, dual-write
+    households: [], // legacy, dual-write
+    current_household: null, // legacy, dual-write
     schema_version: 1,
     created_at: FieldValue.serverTimestamp(),
     updated_at: FieldValue.serverTimestamp(),

--- a/functions/src/features/me/routes.ts
+++ b/functions/src/features/me/routes.ts
@@ -1,7 +1,15 @@
-import {OpenAPIHono, createRoute} from "@hono/zod-openapi";
+import {z, OpenAPIHono, createRoute} from "@hono/zod-openapi";
 import {MeSchema, PatchMeSchema} from "./schemas";
 import {getRequestContext} from "../../core/context/request_context";
 import * as service from "./service";
+
+const ErrorSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    details: z.unknown().optional(),
+  }),
+}).openapi("ApiError");
 
 const getMeRoute = createRoute({
   method: "get",
@@ -9,6 +17,8 @@ const getMeRoute = createRoute({
   tags: ["me"],
   responses: {
     200: {description: "The caller", content: {"application/json": {schema: MeSchema}}},
+    401: {description: "Unauthorized", content: {"application/json": {schema: ErrorSchema}}},
+    404: {description: "User document not found", content: {"application/json": {schema: ErrorSchema}}},
   },
 });
 
@@ -19,6 +29,8 @@ const patchMeRoute = createRoute({
   request: {body: {required: true, content: {"application/json": {schema: PatchMeSchema}}}},
   responses: {
     200: {description: "Updated", content: {"application/json": {schema: MeSchema}}},
+    400: {description: "Validation error", content: {"application/json": {schema: ErrorSchema}}},
+    401: {description: "Unauthorized", content: {"application/json": {schema: ErrorSchema}}},
   },
 });
 

--- a/functions/src/features/me/routes.ts
+++ b/functions/src/features/me/routes.ts
@@ -18,7 +18,10 @@ const getMeRoute = createRoute({
   responses: {
     200: {description: "The caller", content: {"application/json": {schema: MeSchema}}},
     401: {description: "Unauthorized", content: {"application/json": {schema: ErrorSchema}}},
-    404: {description: "User document not found", content: {"application/json": {schema: ErrorSchema}}},
+    404: {
+      description: "User document not found",
+      content: {"application/json": {schema: ErrorSchema}},
+    },
   },
 });
 

--- a/functions/src/features/me/routes.ts
+++ b/functions/src/features/me/routes.ts
@@ -1,0 +1,36 @@
+import {OpenAPIHono, createRoute} from "@hono/zod-openapi";
+import {MeSchema, PatchMeSchema} from "./schemas";
+import {getRequestContext} from "../../core/context/request_context";
+import * as service from "./service";
+
+const getMeRoute = createRoute({
+  method: "get",
+  path: "/v1/me",
+  tags: ["me"],
+  responses: {
+    200: {description: "The caller", content: {"application/json": {schema: MeSchema}}},
+  },
+});
+
+const patchMeRoute = createRoute({
+  method: "patch",
+  path: "/v1/me",
+  tags: ["me"],
+  request: {body: {required: true, content: {"application/json": {schema: PatchMeSchema}}}},
+  responses: {
+    200: {description: "Updated", content: {"application/json": {schema: MeSchema}}},
+  },
+});
+
+export function registerMeRoutes(app: OpenAPIHono): void {
+  app.openapi(getMeRoute, async (c) => {
+    const me = await service.getMe(getRequestContext(c));
+    return c.json(me, 200);
+  });
+
+  app.openapi(patchMeRoute, async (c) => {
+    const patch = c.req.valid("json");
+    const me = await service.patchMe(getRequestContext(c), patch);
+    return c.json(me, 200);
+  });
+}

--- a/functions/src/features/me/schemas.ts
+++ b/functions/src/features/me/schemas.ts
@@ -1,0 +1,17 @@
+import {z} from "@hono/zod-openapi";
+
+export const MeSchema = z.object({
+  uid: z.string(),
+  email: z.string().email().nullable(),
+  displayName: z.string().nullable(),
+  householdIds: z.array(z.string()),
+  currentHouseholdId: z.string().nullable(),
+}).openapi("Me");
+
+export const PatchMeSchema = z.object({
+  currentHouseholdId: z.string().min(1).max(128).optional(),
+  displayName: z.string().min(1).max(128).optional(),
+}).strict().openapi("PatchMe");
+
+export type Me = z.infer<typeof MeSchema>;
+export type PatchMe = z.infer<typeof PatchMeSchema>;

--- a/functions/src/features/me/service.ts
+++ b/functions/src/features/me/service.ts
@@ -1,0 +1,25 @@
+import type {RequestContext} from "../../core/context/request_context";
+import {NotFound} from "../../core/errors/app_error";
+import type {Me, PatchMe} from "./schemas";
+import * as repo from "./repo";
+
+export async function getMe(ctx: RequestContext): Promise<Me> {
+  const me = await repo.readUserDoc(ctx.uid);
+  if (!me) throw new NotFound("User document not provisioned yet");
+  // Auth-token email always wins over the persisted denormalised value.
+  return {...me, email: ctx.email ?? me.email};
+}
+
+export async function patchMe(ctx: RequestContext, patch: PatchMe): Promise<Me> {
+  await repo.patchUserDoc(ctx.uid, patch);
+  return getMe(ctx);
+}
+
+export async function createUser(uid: string, email: string | null): Promise<void> {
+  await repo.createUserDoc(uid, email);
+}
+
+export async function deleteUser(uid: string): Promise<void> {
+  // Phase 1: delete the user doc only. Phase 5 upgrades this to cascade.
+  await repo.deleteUserDoc(uid);
+}

--- a/functions/test/core/errors/handler.test.ts
+++ b/functions/test/core/errors/handler.test.ts
@@ -1,0 +1,66 @@
+import {describe, it, expect} from "vitest";
+import {Hono} from "hono";
+import {installErrorHandler} from "../../../src/core/errors/handler";
+import {
+  AppError, BadRequest, Forbidden, NotFound, Conflict, Unauthorized,
+} from "../../../src/core/errors/app_error";
+
+function appWithThrower(thrown: unknown): Hono {
+  const app = new Hono();
+  installErrorHandler(app);
+  app.get("/boom", () => {
+    throw thrown;
+  });
+  return app;
+}
+
+describe("error handler", () => {
+  it("maps Unauthorized → 401", async () => {
+    const res = await appWithThrower(new Unauthorized("bad token")).request("/boom");
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({error: {code: "UNAUTHORIZED", message: "bad token"}});
+  });
+
+  it("maps Forbidden → 403", async () => {
+    const res = await appWithThrower(new Forbidden("nope")).request("/boom");
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("FORBIDDEN");
+  });
+
+  it("maps NotFound → 404", async () => {
+    const res = await appWithThrower(new NotFound("missing")).request("/boom");
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("NOT_FOUND");
+  });
+
+  it("maps Conflict → 409 with details", async () => {
+    const err = new Conflict("idempotency conflict", {key: "abc"});
+    const res = await appWithThrower(err).request("/boom");
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("CONFLICT");
+    expect(body.error.details).toEqual({key: "abc"});
+  });
+
+  it("maps BadRequest → 400", async () => {
+    const res = await appWithThrower(new BadRequest("bad")).request("/boom");
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe("BAD_REQUEST");
+  });
+
+  it("maps unknown errors → 500 INTERNAL with generic message", async () => {
+    const res = await appWithThrower(new Error("kaboom")).request("/boom");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe("INTERNAL");
+    expect(body.error.message).toBe("Internal server error");
+  });
+
+  it("does not leak details on AppError without details", async () => {
+    const res = await appWithThrower(new AppError("X", "msg", 418)).request("/boom");
+    expect(res.status).toBe(418);
+    const body = await res.json();
+    expect(body.error).toEqual({code: "X", message: "msg"});
+  });
+});

--- a/functions/test/core/middleware/auth.test.ts
+++ b/functions/test/core/middleware/auth.test.ts
@@ -1,0 +1,62 @@
+import {afterAll, beforeAll, describe, it, expect} from "vitest";
+import {OpenAPIHono} from "@hono/zod-openapi";
+import {requestIdMiddleware} from "../../../src/core/middleware/request_id";
+import {authMiddleware} from "../../../src/core/middleware/auth";
+import {installErrorHandler} from "../../../src/core/errors/handler";
+import {getRequestContext} from "../../../src/core/context/request_context";
+import {initializeApp, deleteApp, getApps} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
+
+let testToken: string;
+
+beforeAll(async () => {
+  if (getApps().length === 0) initializeApp({projectId: "fling-rules-test"});
+  const auth = getAuth();
+  const user = await auth.createUser({email: "alice@example.com"});
+  // Build a custom token, then exchange it for an ID token via the emulator.
+  const customToken = await auth.createCustomToken(user.uid);
+  const r = await fetch(
+    `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake`,
+    {method: "POST", body: JSON.stringify({token: customToken, returnSecureToken: true}), headers: {"Content-Type": "application/json"}},
+  );
+  const body = await r.json() as {idToken: string};
+  testToken = body.idToken;
+});
+
+afterAll(async () => {
+  for (const a of getApps()) await deleteApp(a);
+});
+
+function appWithAuth(): OpenAPIHono {
+  const app = new OpenAPIHono();
+  installErrorHandler(app);
+  app.use("*", requestIdMiddleware());
+  app.use("/v1/*", authMiddleware());
+  app.get("/v1/whoami", (c) => {
+    const {uid, email, requestId} = getRequestContext(c);
+    return c.json({uid, email, requestId});
+  });
+  return app;
+}
+
+describe("auth middleware", () => {
+  it("rejects 401 when Authorization header is missing", async () => {
+    const res = await appWithAuth().request("/v1/whoami");
+    expect(res.status).toBe(401);
+    expect((await res.json()).error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects 401 on a malformed token", async () => {
+    const res = await appWithAuth().request("/v1/whoami", {headers: {Authorization: "Bearer not-a-real-token"}});
+    expect(res.status).toBe(401);
+  });
+
+  it("attaches uid + email to RequestContext on a valid token", async () => {
+    const res = await appWithAuth().request("/v1/whoami", {headers: {Authorization: `Bearer ${testToken}`}});
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.uid).toBeTypeOf("string");
+    expect(body.email).toBe("alice@example.com");
+    expect(body.requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});

--- a/functions/test/core/middleware/request_id.test.ts
+++ b/functions/test/core/middleware/request_id.test.ts
@@ -1,0 +1,37 @@
+import {describe, it, expect} from "vitest";
+import {Hono} from "hono";
+import {requestIdMiddleware} from "../../../src/core/middleware/request_id";
+
+function appWithRid(): Hono {
+  const app = new Hono();
+  app.use("*", requestIdMiddleware());
+  app.get("/echo", (c) => c.json({rid: c.get("requestId")}));
+  return app;
+}
+
+describe("requestId middleware", () => {
+  it("generates a UUID-shaped id when X-Request-Id is absent", async () => {
+    const app = appWithRid();
+    const res = await app.request("/echo");
+    const body = await res.json();
+    expect(body.rid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(res.headers.get("x-request-id")).toBe(body.rid);
+  });
+
+  it("honours an incoming X-Request-Id", async () => {
+    const app = appWithRid();
+    const res = await app.request("/echo", {headers: {"X-Request-Id": "client-abc-123"}});
+    const body = await res.json();
+    expect(body.rid).toBe("client-abc-123");
+    expect(res.headers.get("x-request-id")).toBe("client-abc-123");
+  });
+
+  it("rejects an X-Request-Id longer than 128 chars and generates a fresh one", async () => {
+    const app = appWithRid();
+    const long = "a".repeat(200);
+    const res = await app.request("/echo", {headers: {"X-Request-Id": long}});
+    const body = await res.json();
+    expect(body.rid).not.toBe(long);
+    expect(body.rid).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});

--- a/functions/test/features/me/routes.test.ts
+++ b/functions/test/features/me/routes.test.ts
@@ -32,7 +32,6 @@ beforeAll(async () => {
   }
   aliceUid = u.uid;
   aliceToken = await exchangeCustomTokenForId(await getAuth().createCustomToken(u.uid));
-  await service.createUser(u.uid, "alice@example.com");
 });
 
 beforeEach(async () => {
@@ -71,5 +70,37 @@ describe("GET /v1/me", () => {
     expect(body.householdIds).toEqual([]);
     expect(body.currentHouseholdId).toBeNull();
     expect(body.displayName).toBeNull();
+  });
+});
+
+describe("PATCH /v1/me", () => {
+  it("401 without a token", async () => {
+    const res = await buildApp().request("/v1/me", {
+      method: "PATCH",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({displayName: "Alice"}),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("updates displayName and returns the updated doc", async () => {
+    const res = await buildApp().request("/v1/me", {
+      method: "PATCH",
+      headers: {Authorization: `Bearer ${aliceToken}`, "Content-Type": "application/json"},
+      body: JSON.stringify({displayName: "Alice Updated"}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.displayName).toBe("Alice Updated");
+    expect(body.email).toBe("alice@example.com");
+  });
+
+  it("400 on unknown field (strict schema)", async () => {
+    const res = await buildApp().request("/v1/me", {
+      method: "PATCH",
+      headers: {Authorization: `Bearer ${aliceToken}`, "Content-Type": "application/json"},
+      body: JSON.stringify({unknownField: "x"}),
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/functions/test/features/me/routes.test.ts
+++ b/functions/test/features/me/routes.test.ts
@@ -1,0 +1,75 @@
+import {beforeAll, beforeEach, afterAll, describe, it, expect} from "vitest";
+import {OpenAPIHono} from "@hono/zod-openapi";
+import {initializeApp, deleteApp, getApps, type App} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
+import {getFirestore} from "firebase-admin/firestore";
+import {registerMeRoutes} from "../../../src/features/me/module";
+import {requestIdMiddleware} from "../../../src/core/middleware/request_id";
+import {authMiddleware} from "../../../src/core/middleware/auth";
+import {installErrorHandler} from "../../../src/core/errors/handler";
+import * as service from "../../../src/features/me/service";
+
+let firebaseApp: App;
+let aliceToken: string;
+let aliceUid: string;
+
+async function exchangeCustomTokenForId(customToken: string): Promise<string> {
+  const r = await fetch(
+    `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake`,
+    {method: "POST", body: JSON.stringify({token: customToken, returnSecureToken: true}), headers: {"Content-Type": "application/json"}},
+  );
+  return ((await r.json()) as {idToken: string}).idToken;
+}
+
+beforeAll(async () => {
+  firebaseApp = getApps()[0] ?? initializeApp({projectId: "fling-rules-test"});
+  // Reuse the user if alice already exists from a prior test run.
+  let u;
+  try {
+    u = await getAuth().getUserByEmail("alice@example.com");
+  } catch {
+    u = await getAuth().createUser({email: "alice@example.com"});
+  }
+  aliceUid = u.uid;
+  aliceToken = await exchangeCustomTokenForId(await getAuth().createCustomToken(u.uid));
+  await service.createUser(u.uid, "alice@example.com");
+});
+
+beforeEach(async () => {
+  const db = getFirestore();
+  const users = await db.collection("users").listDocuments();
+  await Promise.all(users.map((d) => d.delete()));
+  await service.createUser(aliceUid, "alice@example.com");
+});
+
+afterAll(async () => {
+  if (firebaseApp) await deleteApp(firebaseApp);
+});
+
+function buildApp(): OpenAPIHono {
+  const app = new OpenAPIHono();
+  installErrorHandler(app);
+  app.use("*", requestIdMiddleware());
+  app.use("/v1/*", authMiddleware());
+  registerMeRoutes(app);
+  return app;
+}
+
+describe("GET /v1/me", () => {
+  it("401 without a token", async () => {
+    const res = await buildApp().request("/v1/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the user doc with auth-token email", async () => {
+    const res = await buildApp().request("/v1/me", {
+      headers: {Authorization: `Bearer ${aliceToken}`},
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.email).toBe("alice@example.com");
+    expect(body.householdIds).toEqual([]);
+    expect(body.currentHouseholdId).toBeNull();
+    expect(body.displayName).toBeNull();
+  });
+});

--- a/functions/test/features/me/service.test.ts
+++ b/functions/test/features/me/service.test.ts
@@ -1,0 +1,60 @@
+import {beforeAll, beforeEach, afterAll, describe, it, expect} from "vitest";
+import {initializeApp, deleteApp, getApps, type App} from "firebase-admin/app";
+import {getFirestore} from "firebase-admin/firestore";
+import * as service from "../../../src/features/me/service";
+import {NotFound} from "../../../src/core/errors/app_error";
+
+let app: App;
+
+beforeAll(() => {
+  app = getApps()[0] ?? initializeApp({projectId: "fling-rules-test"});
+});
+beforeEach(async () => {
+  const db = getFirestore();
+  const docs = await db.collection("users").listDocuments();
+  await Promise.all(docs.map((d) => d.delete()));
+});
+afterAll(async () => {
+  if (app) await deleteApp(app);
+});
+
+const ctx = {uid: "alice", email: "alice@example.com", requestId: "rid"};
+
+describe("me.service", () => {
+  it("getMe throws NotFound when the user doc does not exist", async () => {
+    await expect(service.getMe(ctx)).rejects.toThrow(NotFound);
+  });
+
+  it("createUser then getMe returns the new doc", async () => {
+    await service.createUser("alice", "alice@example.com");
+    const me = await service.getMe(ctx);
+    expect(me).toEqual({
+      uid: "alice",
+      email: "alice@example.com",
+      displayName: null,
+      householdIds: [],
+      currentHouseholdId: null,
+    });
+  });
+
+  it("patchMe sets currentHouseholdId and dual-writes the legacy field", async () => {
+    await service.createUser("alice", "alice@example.com");
+    await service.patchMe(ctx, {currentHouseholdId: "h1"});
+    const raw = (await getFirestore().doc("users/alice").get()).data();
+    expect(raw?.current_household_id).toBe("h1");
+    expect(raw?.current_household).toBe("h1");
+  });
+
+  it("patchMe sets displayName", async () => {
+    await service.createUser("alice", "alice@example.com");
+    const me = await service.patchMe(ctx, {displayName: "Alice"});
+    expect(me.displayName).toBe("Alice");
+  });
+
+  it("deleteUser removes the doc", async () => {
+    await service.createUser("alice", null);
+    await service.deleteUser("alice");
+    const snap = await getFirestore().doc("users/alice").get();
+    expect(snap.exists).toBe(false);
+  });
+});

--- a/lib/core/api/generated/.openapi-generator/FILES
+++ b/lib/core/api/generated/.openapi-generator/FILES
@@ -2,6 +2,8 @@
 .openapi-generator-ignore
 README.md
 analysis_options.yaml
+doc/ApiError.md
+doc/ApiErrorError.md
 doc/DefaultApi.md
 doc/Health.md
 doc/Me.md
@@ -18,12 +20,16 @@ lib/src/auth/basic_auth.dart
 lib/src/auth/bearer_auth.dart
 lib/src/auth/oauth.dart
 lib/src/date_serializer.dart
+lib/src/model/api_error.dart
+lib/src/model/api_error_error.dart
 lib/src/model/date.dart
 lib/src/model/health.dart
 lib/src/model/me.dart
 lib/src/model/patch_me.dart
 lib/src/serializers.dart
 pubspec.yaml
+test/api_error_error_test.dart
+test/api_error_test.dart
 test/default_api_test.dart
 test/health_test.dart
 test/me_api_test.dart

--- a/lib/core/api/generated/.openapi-generator/FILES
+++ b/lib/core/api/generated/.openapi-generator/FILES
@@ -4,9 +4,13 @@ README.md
 analysis_options.yaml
 doc/DefaultApi.md
 doc/Health.md
+doc/Me.md
+doc/MeApi.md
+doc/PatchMe.md
 lib/fling_api.dart
 lib/src/api.dart
 lib/src/api/default_api.dart
+lib/src/api/me_api.dart
 lib/src/api_util.dart
 lib/src/auth/api_key_auth.dart
 lib/src/auth/auth.dart
@@ -16,7 +20,12 @@ lib/src/auth/oauth.dart
 lib/src/date_serializer.dart
 lib/src/model/date.dart
 lib/src/model/health.dart
+lib/src/model/me.dart
+lib/src/model/patch_me.dart
 lib/src/serializers.dart
 pubspec.yaml
 test/default_api_test.dart
 test/health_test.dart
+test/me_api_test.dart
+test/me_test.dart
+test/patch_me_test.dart

--- a/lib/core/api/generated/README.md
+++ b/lib/core/api/generated/README.md
@@ -71,6 +71,8 @@ Class | Method | HTTP request | Description
 
 ## Documentation For Models
 
+ - [ApiError](doc/ApiError.md)
+ - [ApiErrorError](doc/ApiErrorError.md)
  - [Health](doc/Health.md)
  - [Me](doc/Me.md)
  - [PatchMe](doc/PatchMe.md)

--- a/lib/core/api/generated/README.md
+++ b/lib/core/api/generated/README.md
@@ -65,11 +65,15 @@ All URIs are relative to *http://localhost*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 [*DefaultApi*](doc/DefaultApi.md) | [**v1HealthzGet**](doc/DefaultApi.md#v1healthzget) | **GET** /v1/healthz | 
+[*MeApi*](doc/MeApi.md) | [**v1MeGet**](doc/MeApi.md#v1meget) | **GET** /v1/me | 
+[*MeApi*](doc/MeApi.md) | [**v1MePatch**](doc/MeApi.md#v1mepatch) | **PATCH** /v1/me | 
 
 
 ## Documentation For Models
 
  - [Health](doc/Health.md)
+ - [Me](doc/Me.md)
+ - [PatchMe](doc/PatchMe.md)
 
 
 ## Documentation For Authorization

--- a/lib/core/api/generated/doc/ApiError.md
+++ b/lib/core/api/generated/doc/ApiError.md
@@ -1,0 +1,15 @@
+# fling_api.model.ApiError
+
+## Load the model package
+```dart
+import 'package:fling_api/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**error** | [**ApiErrorError**](ApiErrorError.md) |  | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/lib/core/api/generated/doc/ApiErrorError.md
+++ b/lib/core/api/generated/doc/ApiErrorError.md
@@ -1,0 +1,17 @@
+# fling_api.model.ApiErrorError
+
+## Load the model package
+```dart
+import 'package:fling_api/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**code** | **String** |  | 
+**message** | **String** |  | 
+**details** | [**JsonObject**](.md) |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/lib/core/api/generated/doc/Me.md
+++ b/lib/core/api/generated/doc/Me.md
@@ -1,0 +1,19 @@
+# fling_api.model.Me
+
+## Load the model package
+```dart
+import 'package:fling_api/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**uid** | **String** |  | 
+**email** | **String** |  | 
+**displayName** | **String** |  | 
+**householdIds** | **BuiltList&lt;String&gt;** |  | 
+**currentHouseholdId** | **String** |  | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/lib/core/api/generated/doc/MeApi.md
+++ b/lib/core/api/generated/doc/MeApi.md
@@ -1,0 +1,93 @@
+# fling_api.api.MeApi
+
+## Load the API package
+```dart
+import 'package:fling_api/api.dart';
+```
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**v1MeGet**](MeApi.md#v1meget) | **GET** /v1/me | 
+[**v1MePatch**](MeApi.md#v1mepatch) | **PATCH** /v1/me | 
+
+
+# **v1MeGet**
+> Me v1MeGet()
+
+
+
+### Example
+```dart
+import 'package:fling_api/api.dart';
+
+final api = FlingApi().getMeApi();
+
+try {
+    final response = api.v1MeGet();
+    print(response);
+} on DioException catch (e) {
+    print('Exception when calling MeApi->v1MeGet: $e\n');
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**Me**](Me.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **v1MePatch**
+> Me v1MePatch(patchMe)
+
+
+
+### Example
+```dart
+import 'package:fling_api/api.dart';
+
+final api = FlingApi().getMeApi();
+final PatchMe patchMe = ; // PatchMe | 
+
+try {
+    final response = api.v1MePatch(patchMe);
+    print(response);
+} on DioException catch (e) {
+    print('Exception when calling MeApi->v1MePatch: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **patchMe** | [**PatchMe**](PatchMe.md)|  | 
+
+### Return type
+
+[**Me**](Me.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+

--- a/lib/core/api/generated/doc/PatchMe.md
+++ b/lib/core/api/generated/doc/PatchMe.md
@@ -1,0 +1,16 @@
+# fling_api.model.PatchMe
+
+## Load the model package
+```dart
+import 'package:fling_api/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**currentHouseholdId** | **String** |  | [optional] 
+**displayName** | **String** |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/lib/core/api/generated/lib/fling_api.dart
+++ b/lib/core/api/generated/lib/fling_api.dart
@@ -13,6 +13,8 @@ export 'package:fling_api/src/model/date.dart';
 export 'package:fling_api/src/api/default_api.dart';
 export 'package:fling_api/src/api/me_api.dart';
 
+export 'package:fling_api/src/model/api_error.dart';
+export 'package:fling_api/src/model/api_error_error.dart';
 export 'package:fling_api/src/model/health.dart';
 export 'package:fling_api/src/model/me.dart';
 export 'package:fling_api/src/model/patch_me.dart';

--- a/lib/core/api/generated/lib/fling_api.dart
+++ b/lib/core/api/generated/lib/fling_api.dart
@@ -11,6 +11,9 @@ export 'package:fling_api/src/serializers.dart';
 export 'package:fling_api/src/model/date.dart';
 
 export 'package:fling_api/src/api/default_api.dart';
+export 'package:fling_api/src/api/me_api.dart';
 
 export 'package:fling_api/src/model/health.dart';
+export 'package:fling_api/src/model/me.dart';
+export 'package:fling_api/src/model/patch_me.dart';
 

--- a/lib/core/api/generated/lib/src/api.dart
+++ b/lib/core/api/generated/lib/src/api.dart
@@ -10,6 +10,7 @@ import 'package:fling_api/src/auth/basic_auth.dart';
 import 'package:fling_api/src/auth/bearer_auth.dart';
 import 'package:fling_api/src/auth/oauth.dart';
 import 'package:fling_api/src/api/default_api.dart';
+import 'package:fling_api/src/api/me_api.dart';
 
 class FlingApi {
   static const String basePath = r'http://localhost';
@@ -69,5 +70,11 @@ class FlingApi {
   /// by doing that all interceptors will not be executed
   DefaultApi getDefaultApi() {
     return DefaultApi(dio, serializers);
+  }
+
+  /// Get MeApi instance, base route and serializer can be overridden by a given but be careful,
+  /// by doing that all interceptors will not be executed
+  MeApi getMeApi() {
+    return MeApi(dio, serializers);
   }
 }

--- a/lib/core/api/generated/lib/src/api/me_api.dart
+++ b/lib/core/api/generated/lib/src/api/me_api.dart
@@ -8,6 +8,7 @@ import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:dio/dio.dart';
 
+import 'package:fling_api/src/model/api_error.dart';
 import 'package:fling_api/src/model/me.dart';
 import 'package:fling_api/src/model/patch_me.dart';
 

--- a/lib/core/api/generated/lib/src/api/me_api.dart
+++ b/lib/core/api/generated/lib/src/api/me_api.dart
@@ -1,0 +1,190 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+import 'dart:async';
+
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:dio/dio.dart';
+
+import 'package:fling_api/src/model/me.dart';
+import 'package:fling_api/src/model/patch_me.dart';
+
+class MeApi {
+
+  final Dio _dio;
+
+  final Serializers _serializers;
+
+  const MeApi(this._dio, this._serializers);
+
+  /// v1MeGet
+  /// 
+  ///
+  /// Parameters:
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [Me] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<Me>> v1MeGet({ 
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/v1/me';
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    Me? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: const FullType(Me),
+      ) as Me;
+
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<Me>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// v1MePatch
+  /// 
+  ///
+  /// Parameters:
+  /// * [patchMe] 
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [Me] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<Me>> v1MePatch({ 
+    required PatchMe patchMe,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/v1/me';
+    final _options = Options(
+      method: r'PATCH',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[],
+        ...?extra,
+      },
+      contentType: 'application/json',
+      validateStatus: validateStatus,
+    );
+
+    dynamic _bodyData;
+
+    try {
+      const _type = FullType(PatchMe);
+      _bodyData = _serializers.serialize(patchMe, specifiedType: _type);
+
+    } catch(error, stackTrace) {
+      throw DioException(
+         requestOptions: _options.compose(
+          _dio.options,
+          _path,
+        ),
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    final _response = await _dio.request<Object>(
+      _path,
+      data: _bodyData,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    Me? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: const FullType(Me),
+      ) as Me;
+
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<Me>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+}

--- a/lib/core/api/generated/lib/src/model/api_error.dart
+++ b/lib/core/api/generated/lib/src/model/api_error.dart
@@ -1,0 +1,107 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+// ignore_for_file: unused_element
+import 'package:fling_api/src/model/api_error_error.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'api_error.g.dart';
+
+/// ApiError
+///
+/// Properties:
+/// * [error] 
+@BuiltValue()
+abstract class ApiError implements Built<ApiError, ApiErrorBuilder> {
+  @BuiltValueField(wireName: r'error')
+  ApiErrorError get error;
+
+  ApiError._();
+
+  factory ApiError([void updates(ApiErrorBuilder b)]) = _$ApiError;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiErrorBuilder b) => b;
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ApiError> get serializer => _$ApiErrorSerializer();
+}
+
+class _$ApiErrorSerializer implements PrimitiveSerializer<ApiError> {
+  @override
+  final Iterable<Type> types = const [ApiError, _$ApiError];
+
+  @override
+  final String wireName = r'ApiError';
+
+  Iterable<Object?> _serializeProperties(
+    Serializers serializers,
+    ApiError object, {
+    FullType specifiedType = FullType.unspecified,
+  }) sync* {
+    yield r'error';
+    yield serializers.serialize(
+      object.error,
+      specifiedType: const FullType(ApiErrorError),
+    );
+  }
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ApiError object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return _serializeProperties(serializers, object, specifiedType: specifiedType).toList();
+  }
+
+  void _deserializeProperties(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+    required List<Object?> serializedList,
+    required ApiErrorBuilder result,
+    required List<Object?> unhandled,
+  }) {
+    for (var i = 0; i < serializedList.length; i += 2) {
+      final key = serializedList[i] as String;
+      final value = serializedList[i + 1];
+      switch (key) {
+        case r'error':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(ApiErrorError),
+          ) as ApiErrorError;
+          result.error.replace(valueDes);
+          break;
+        default:
+          unhandled.add(key);
+          unhandled.add(value);
+          break;
+      }
+    }
+  }
+
+  @override
+  ApiError deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ApiErrorBuilder();
+    final serializedList = (serialized as Iterable<Object?>).toList();
+    final unhandled = <Object?>[];
+    _deserializeProperties(
+      serializers,
+      serialized,
+      specifiedType: specifiedType,
+      serializedList: serializedList,
+      unhandled: unhandled,
+      result: result,
+    );
+    return result.build();
+  }
+}
+

--- a/lib/core/api/generated/lib/src/model/api_error.g.dart
+++ b/lib/core/api/generated/lib/src/model/api_error.g.dart
@@ -1,0 +1,101 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api_error.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$ApiError extends ApiError {
+  @override
+  final ApiErrorError error;
+
+  factory _$ApiError([void Function(ApiErrorBuilder)? updates]) =>
+      (ApiErrorBuilder()..update(updates))._build();
+
+  _$ApiError._({required this.error}) : super._();
+  @override
+  ApiError rebuild(void Function(ApiErrorBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ApiErrorBuilder toBuilder() => ApiErrorBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ApiError && error == other.error;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, error.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ApiError')..add('error', error))
+        .toString();
+  }
+}
+
+class ApiErrorBuilder implements Builder<ApiError, ApiErrorBuilder> {
+  _$ApiError? _$v;
+
+  ApiErrorErrorBuilder? _error;
+  ApiErrorErrorBuilder get error => _$this._error ??= ApiErrorErrorBuilder();
+  set error(ApiErrorErrorBuilder? error) => _$this._error = error;
+
+  ApiErrorBuilder() {
+    ApiError._defaults(this);
+  }
+
+  ApiErrorBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _error = $v.error.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ApiError other) {
+    _$v = other as _$ApiError;
+  }
+
+  @override
+  void update(void Function(ApiErrorBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ApiError build() => _build();
+
+  _$ApiError _build() {
+    _$ApiError _$result;
+    try {
+      _$result = _$v ??
+          _$ApiError._(
+            error: error.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'error';
+        error.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'ApiError', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/lib/core/api/generated/lib/src/model/api_error_error.dart
+++ b/lib/core/api/generated/lib/src/model/api_error_error.dart
@@ -1,0 +1,142 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+// ignore_for_file: unused_element
+import 'package:built_value/json_object.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'api_error_error.g.dart';
+
+/// ApiErrorError
+///
+/// Properties:
+/// * [code] 
+/// * [message] 
+/// * [details] 
+@BuiltValue()
+abstract class ApiErrorError implements Built<ApiErrorError, ApiErrorErrorBuilder> {
+  @BuiltValueField(wireName: r'code')
+  String get code;
+
+  @BuiltValueField(wireName: r'message')
+  String get message;
+
+  @BuiltValueField(wireName: r'details')
+  JsonObject? get details;
+
+  ApiErrorError._();
+
+  factory ApiErrorError([void updates(ApiErrorErrorBuilder b)]) = _$ApiErrorError;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiErrorErrorBuilder b) => b;
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ApiErrorError> get serializer => _$ApiErrorErrorSerializer();
+}
+
+class _$ApiErrorErrorSerializer implements PrimitiveSerializer<ApiErrorError> {
+  @override
+  final Iterable<Type> types = const [ApiErrorError, _$ApiErrorError];
+
+  @override
+  final String wireName = r'ApiErrorError';
+
+  Iterable<Object?> _serializeProperties(
+    Serializers serializers,
+    ApiErrorError object, {
+    FullType specifiedType = FullType.unspecified,
+  }) sync* {
+    yield r'code';
+    yield serializers.serialize(
+      object.code,
+      specifiedType: const FullType(String),
+    );
+    yield r'message';
+    yield serializers.serialize(
+      object.message,
+      specifiedType: const FullType(String),
+    );
+    if (object.details != null) {
+      yield r'details';
+      yield serializers.serialize(
+        object.details,
+        specifiedType: const FullType.nullable(JsonObject),
+      );
+    }
+  }
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ApiErrorError object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return _serializeProperties(serializers, object, specifiedType: specifiedType).toList();
+  }
+
+  void _deserializeProperties(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+    required List<Object?> serializedList,
+    required ApiErrorErrorBuilder result,
+    required List<Object?> unhandled,
+  }) {
+    for (var i = 0; i < serializedList.length; i += 2) {
+      final key = serializedList[i] as String;
+      final value = serializedList[i + 1];
+      switch (key) {
+        case r'code':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.code = valueDes;
+          break;
+        case r'message':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.message = valueDes;
+          break;
+        case r'details':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(JsonObject),
+          ) as JsonObject?;
+          if (valueDes == null) continue;
+          result.details = valueDes;
+          break;
+        default:
+          unhandled.add(key);
+          unhandled.add(value);
+          break;
+      }
+    }
+  }
+
+  @override
+  ApiErrorError deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ApiErrorErrorBuilder();
+    final serializedList = (serialized as Iterable<Object?>).toList();
+    final unhandled = <Object?>[];
+    _deserializeProperties(
+      serializers,
+      serialized,
+      specifiedType: specifiedType,
+      serializedList: serializedList,
+      unhandled: unhandled,
+      result: result,
+    );
+    return result.build();
+  }
+}
+

--- a/lib/core/api/generated/lib/src/model/api_error_error.g.dart
+++ b/lib/core/api/generated/lib/src/model/api_error_error.g.dart
@@ -1,0 +1,116 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api_error_error.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$ApiErrorError extends ApiErrorError {
+  @override
+  final String code;
+  @override
+  final String message;
+  @override
+  final JsonObject? details;
+
+  factory _$ApiErrorError([void Function(ApiErrorErrorBuilder)? updates]) =>
+      (ApiErrorErrorBuilder()..update(updates))._build();
+
+  _$ApiErrorError._({required this.code, required this.message, this.details})
+      : super._();
+  @override
+  ApiErrorError rebuild(void Function(ApiErrorErrorBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ApiErrorErrorBuilder toBuilder() => ApiErrorErrorBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ApiErrorError &&
+        code == other.code &&
+        message == other.message &&
+        details == other.details;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, code.hashCode);
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jc(_$hash, details.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ApiErrorError')
+          ..add('code', code)
+          ..add('message', message)
+          ..add('details', details))
+        .toString();
+  }
+}
+
+class ApiErrorErrorBuilder
+    implements Builder<ApiErrorError, ApiErrorErrorBuilder> {
+  _$ApiErrorError? _$v;
+
+  String? _code;
+  String? get code => _$this._code;
+  set code(String? code) => _$this._code = code;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  JsonObject? _details;
+  JsonObject? get details => _$this._details;
+  set details(JsonObject? details) => _$this._details = details;
+
+  ApiErrorErrorBuilder() {
+    ApiErrorError._defaults(this);
+  }
+
+  ApiErrorErrorBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _code = $v.code;
+      _message = $v.message;
+      _details = $v.details;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ApiErrorError other) {
+    _$v = other as _$ApiErrorError;
+  }
+
+  @override
+  void update(void Function(ApiErrorErrorBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ApiErrorError build() => _build();
+
+  _$ApiErrorError _build() {
+    final _$result = _$v ??
+        _$ApiErrorError._(
+          code: BuiltValueNullFieldError.checkNotNull(
+              code, r'ApiErrorError', 'code'),
+          message: BuiltValueNullFieldError.checkNotNull(
+              message, r'ApiErrorError', 'message'),
+          details: details,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/lib/core/api/generated/lib/src/model/me.dart
+++ b/lib/core/api/generated/lib/src/model/me.dart
@@ -1,0 +1,174 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+// ignore_for_file: unused_element
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'me.g.dart';
+
+/// Me
+///
+/// Properties:
+/// * [uid] 
+/// * [email] 
+/// * [displayName] 
+/// * [householdIds] 
+/// * [currentHouseholdId] 
+@BuiltValue()
+abstract class Me implements Built<Me, MeBuilder> {
+  @BuiltValueField(wireName: r'uid')
+  String get uid;
+
+  @BuiltValueField(wireName: r'email')
+  String? get email;
+
+  @BuiltValueField(wireName: r'displayName')
+  String? get displayName;
+
+  @BuiltValueField(wireName: r'householdIds')
+  BuiltList<String> get householdIds;
+
+  @BuiltValueField(wireName: r'currentHouseholdId')
+  String? get currentHouseholdId;
+
+  Me._();
+
+  factory Me([void updates(MeBuilder b)]) = _$Me;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MeBuilder b) => b;
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<Me> get serializer => _$MeSerializer();
+}
+
+class _$MeSerializer implements PrimitiveSerializer<Me> {
+  @override
+  final Iterable<Type> types = const [Me, _$Me];
+
+  @override
+  final String wireName = r'Me';
+
+  Iterable<Object?> _serializeProperties(
+    Serializers serializers,
+    Me object, {
+    FullType specifiedType = FullType.unspecified,
+  }) sync* {
+    yield r'uid';
+    yield serializers.serialize(
+      object.uid,
+      specifiedType: const FullType(String),
+    );
+    yield r'email';
+    yield object.email == null ? null : serializers.serialize(
+      object.email,
+      specifiedType: const FullType.nullable(String),
+    );
+    yield r'displayName';
+    yield object.displayName == null ? null : serializers.serialize(
+      object.displayName,
+      specifiedType: const FullType.nullable(String),
+    );
+    yield r'householdIds';
+    yield serializers.serialize(
+      object.householdIds,
+      specifiedType: const FullType(BuiltList, [FullType(String)]),
+    );
+    yield r'currentHouseholdId';
+    yield object.currentHouseholdId == null ? null : serializers.serialize(
+      object.currentHouseholdId,
+      specifiedType: const FullType.nullable(String),
+    );
+  }
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    Me object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return _serializeProperties(serializers, object, specifiedType: specifiedType).toList();
+  }
+
+  void _deserializeProperties(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+    required List<Object?> serializedList,
+    required MeBuilder result,
+    required List<Object?> unhandled,
+  }) {
+    for (var i = 0; i < serializedList.length; i += 2) {
+      final key = serializedList[i] as String;
+      final value = serializedList[i + 1];
+      switch (key) {
+        case r'uid':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.uid = valueDes;
+          break;
+        case r'email':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.email = valueDes;
+          break;
+        case r'displayName':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.displayName = valueDes;
+          break;
+        case r'householdIds':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(String)]),
+          ) as BuiltList<String>;
+          result.householdIds.replace(valueDes);
+          break;
+        case r'currentHouseholdId':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.currentHouseholdId = valueDes;
+          break;
+        default:
+          unhandled.add(key);
+          unhandled.add(value);
+          break;
+      }
+    }
+  }
+
+  @override
+  Me deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = MeBuilder();
+    final serializedList = (serialized as Iterable<Object?>).toList();
+    final unhandled = <Object?>[];
+    _deserializeProperties(
+      serializers,
+      serialized,
+      specifiedType: specifiedType,
+      serializedList: serializedList,
+      unhandled: unhandled,
+      result: result,
+    );
+    return result.build();
+  }
+}
+

--- a/lib/core/api/generated/lib/src/model/me.g.dart
+++ b/lib/core/api/generated/lib/src/model/me.g.dart
@@ -1,0 +1,155 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'me.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$Me extends Me {
+  @override
+  final String uid;
+  @override
+  final String? email;
+  @override
+  final String? displayName;
+  @override
+  final BuiltList<String> householdIds;
+  @override
+  final String? currentHouseholdId;
+
+  factory _$Me([void Function(MeBuilder)? updates]) =>
+      (MeBuilder()..update(updates))._build();
+
+  _$Me._(
+      {required this.uid,
+      this.email,
+      this.displayName,
+      required this.householdIds,
+      this.currentHouseholdId})
+      : super._();
+  @override
+  Me rebuild(void Function(MeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  MeBuilder toBuilder() => MeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Me &&
+        uid == other.uid &&
+        email == other.email &&
+        displayName == other.displayName &&
+        householdIds == other.householdIds &&
+        currentHouseholdId == other.currentHouseholdId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, uid.hashCode);
+    _$hash = $jc(_$hash, email.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, householdIds.hashCode);
+    _$hash = $jc(_$hash, currentHouseholdId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Me')
+          ..add('uid', uid)
+          ..add('email', email)
+          ..add('displayName', displayName)
+          ..add('householdIds', householdIds)
+          ..add('currentHouseholdId', currentHouseholdId))
+        .toString();
+  }
+}
+
+class MeBuilder implements Builder<Me, MeBuilder> {
+  _$Me? _$v;
+
+  String? _uid;
+  String? get uid => _$this._uid;
+  set uid(String? uid) => _$this._uid = uid;
+
+  String? _email;
+  String? get email => _$this._email;
+  set email(String? email) => _$this._email = email;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ListBuilder<String>? _householdIds;
+  ListBuilder<String> get householdIds =>
+      _$this._householdIds ??= ListBuilder<String>();
+  set householdIds(ListBuilder<String>? householdIds) =>
+      _$this._householdIds = householdIds;
+
+  String? _currentHouseholdId;
+  String? get currentHouseholdId => _$this._currentHouseholdId;
+  set currentHouseholdId(String? currentHouseholdId) =>
+      _$this._currentHouseholdId = currentHouseholdId;
+
+  MeBuilder() {
+    Me._defaults(this);
+  }
+
+  MeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _uid = $v.uid;
+      _email = $v.email;
+      _displayName = $v.displayName;
+      _householdIds = $v.householdIds.toBuilder();
+      _currentHouseholdId = $v.currentHouseholdId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Me other) {
+    _$v = other as _$Me;
+  }
+
+  @override
+  void update(void Function(MeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Me build() => _build();
+
+  _$Me _build() {
+    _$Me _$result;
+    try {
+      _$result = _$v ??
+          _$Me._(
+            uid: BuiltValueNullFieldError.checkNotNull(uid, r'Me', 'uid'),
+            email: email,
+            displayName: displayName,
+            householdIds: householdIds.build(),
+            currentHouseholdId: currentHouseholdId,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'householdIds';
+        householdIds.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'Me', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/lib/core/api/generated/lib/src/model/patch_me.dart
+++ b/lib/core/api/generated/lib/src/model/patch_me.dart
@@ -1,0 +1,126 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+// ignore_for_file: unused_element
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'patch_me.g.dart';
+
+/// PatchMe
+///
+/// Properties:
+/// * [currentHouseholdId] 
+/// * [displayName] 
+@BuiltValue()
+abstract class PatchMe implements Built<PatchMe, PatchMeBuilder> {
+  @BuiltValueField(wireName: r'currentHouseholdId')
+  String? get currentHouseholdId;
+
+  @BuiltValueField(wireName: r'displayName')
+  String? get displayName;
+
+  PatchMe._();
+
+  factory PatchMe([void updates(PatchMeBuilder b)]) = _$PatchMe;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PatchMeBuilder b) => b;
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PatchMe> get serializer => _$PatchMeSerializer();
+}
+
+class _$PatchMeSerializer implements PrimitiveSerializer<PatchMe> {
+  @override
+  final Iterable<Type> types = const [PatchMe, _$PatchMe];
+
+  @override
+  final String wireName = r'PatchMe';
+
+  Iterable<Object?> _serializeProperties(
+    Serializers serializers,
+    PatchMe object, {
+    FullType specifiedType = FullType.unspecified,
+  }) sync* {
+    if (object.currentHouseholdId != null) {
+      yield r'currentHouseholdId';
+      yield serializers.serialize(
+        object.currentHouseholdId,
+        specifiedType: const FullType(String),
+      );
+    }
+    if (object.displayName != null) {
+      yield r'displayName';
+      yield serializers.serialize(
+        object.displayName,
+        specifiedType: const FullType(String),
+      );
+    }
+  }
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PatchMe object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return _serializeProperties(serializers, object, specifiedType: specifiedType).toList();
+  }
+
+  void _deserializeProperties(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+    required List<Object?> serializedList,
+    required PatchMeBuilder result,
+    required List<Object?> unhandled,
+  }) {
+    for (var i = 0; i < serializedList.length; i += 2) {
+      final key = serializedList[i] as String;
+      final value = serializedList[i + 1];
+      switch (key) {
+        case r'currentHouseholdId':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.currentHouseholdId = valueDes;
+          break;
+        case r'displayName':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.displayName = valueDes;
+          break;
+        default:
+          unhandled.add(key);
+          unhandled.add(value);
+          break;
+      }
+    }
+  }
+
+  @override
+  PatchMe deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = PatchMeBuilder();
+    final serializedList = (serialized as Iterable<Object?>).toList();
+    final unhandled = <Object?>[];
+    _deserializeProperties(
+      serializers,
+      serialized,
+      specifiedType: specifiedType,
+      serializedList: serializedList,
+      unhandled: unhandled,
+      result: result,
+    );
+    return result.build();
+  }
+}
+

--- a/lib/core/api/generated/lib/src/model/patch_me.g.dart
+++ b/lib/core/api/generated/lib/src/model/patch_me.g.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'patch_me.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$PatchMe extends PatchMe {
+  @override
+  final String? currentHouseholdId;
+  @override
+  final String? displayName;
+
+  factory _$PatchMe([void Function(PatchMeBuilder)? updates]) =>
+      (PatchMeBuilder()..update(updates))._build();
+
+  _$PatchMe._({this.currentHouseholdId, this.displayName}) : super._();
+  @override
+  PatchMe rebuild(void Function(PatchMeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PatchMeBuilder toBuilder() => PatchMeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PatchMe &&
+        currentHouseholdId == other.currentHouseholdId &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, currentHouseholdId.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PatchMe')
+          ..add('currentHouseholdId', currentHouseholdId)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class PatchMeBuilder implements Builder<PatchMe, PatchMeBuilder> {
+  _$PatchMe? _$v;
+
+  String? _currentHouseholdId;
+  String? get currentHouseholdId => _$this._currentHouseholdId;
+  set currentHouseholdId(String? currentHouseholdId) =>
+      _$this._currentHouseholdId = currentHouseholdId;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  PatchMeBuilder() {
+    PatchMe._defaults(this);
+  }
+
+  PatchMeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _currentHouseholdId = $v.currentHouseholdId;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PatchMe other) {
+    _$v = other as _$PatchMe;
+  }
+
+  @override
+  void update(void Function(PatchMeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PatchMe build() => _build();
+
+  _$PatchMe _build() {
+    final _$result = _$v ??
+        _$PatchMe._(
+          currentHouseholdId: currentHouseholdId,
+          displayName: displayName,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/lib/core/api/generated/lib/src/serializers.dart
+++ b/lib/core/api/generated/lib/src/serializers.dart
@@ -14,6 +14,8 @@ import 'package:built_value/iso_8601_date_time_serializer.dart';
 import 'package:fling_api/src/date_serializer.dart';
 import 'package:fling_api/src/model/date.dart';
 
+import 'package:fling_api/src/model/api_error.dart';
+import 'package:fling_api/src/model/api_error_error.dart';
 import 'package:fling_api/src/model/health.dart';
 import 'package:fling_api/src/model/me.dart';
 import 'package:fling_api/src/model/patch_me.dart';
@@ -21,6 +23,8 @@ import 'package:fling_api/src/model/patch_me.dart';
 part 'serializers.g.dart';
 
 @SerializersFor([
+  ApiError,
+  ApiErrorError,
   Health,
   Me,
   PatchMe,

--- a/lib/core/api/generated/lib/src/serializers.dart
+++ b/lib/core/api/generated/lib/src/serializers.dart
@@ -15,11 +15,15 @@ import 'package:fling_api/src/date_serializer.dart';
 import 'package:fling_api/src/model/date.dart';
 
 import 'package:fling_api/src/model/health.dart';
+import 'package:fling_api/src/model/me.dart';
+import 'package:fling_api/src/model/patch_me.dart';
 
 part 'serializers.g.dart';
 
 @SerializersFor([
   Health,
+  Me,
+  PatchMe,
 ])
 Serializers serializers = (_$serializers.toBuilder()
       ..add(const OneOfSerializer())

--- a/lib/core/api/generated/lib/src/serializers.g.dart
+++ b/lib/core/api/generated/lib/src/serializers.g.dart
@@ -7,6 +7,8 @@ part of 'serializers.dart';
 // **************************************************************************
 
 Serializers _$serializers = (Serializers().toBuilder()
+      ..add(ApiError.serializer)
+      ..add(ApiErrorError.serializer)
       ..add(Health.serializer)
       ..add(HealthStatusEnum.serializer)
       ..add(Me.serializer)

--- a/lib/core/api/generated/lib/src/serializers.g.dart
+++ b/lib/core/api/generated/lib/src/serializers.g.dart
@@ -8,7 +8,12 @@ part of 'serializers.dart';
 
 Serializers _$serializers = (Serializers().toBuilder()
       ..add(Health.serializer)
-      ..add(HealthStatusEnum.serializer))
+      ..add(HealthStatusEnum.serializer)
+      ..add(Me.serializer)
+      ..add(PatchMe.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => ListBuilder<String>()))
     .build();
 
 // ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/lib/core/api/generated/test/api_error_error_test.dart
+++ b/lib/core/api/generated/test/api_error_error_test.dart
@@ -1,0 +1,26 @@
+import 'package:test/test.dart';
+import 'package:fling_api/fling_api.dart';
+
+// tests for ApiErrorError
+void main() {
+  final instance = ApiErrorErrorBuilder();
+  // TODO add properties to the builder and call build()
+
+  group(ApiErrorError, () {
+    // String code
+    test('to test the property `code`', () async {
+      // TODO
+    });
+
+    // String message
+    test('to test the property `message`', () async {
+      // TODO
+    });
+
+    // JsonObject details
+    test('to test the property `details`', () async {
+      // TODO
+    });
+
+  });
+}

--- a/lib/core/api/generated/test/api_error_test.dart
+++ b/lib/core/api/generated/test/api_error_test.dart
@@ -1,0 +1,16 @@
+import 'package:test/test.dart';
+import 'package:fling_api/fling_api.dart';
+
+// tests for ApiError
+void main() {
+  final instance = ApiErrorBuilder();
+  // TODO add properties to the builder and call build()
+
+  group(ApiError, () {
+    // ApiErrorError error
+    test('to test the property `error`', () async {
+      // TODO
+    });
+
+  });
+}

--- a/lib/core/api/generated/test/me_api_test.dart
+++ b/lib/core/api/generated/test/me_api_test.dart
@@ -1,0 +1,21 @@
+import 'package:test/test.dart';
+import 'package:fling_api/fling_api.dart';
+
+
+/// tests for MeApi
+void main() {
+  final instance = FlingApi().getMeApi();
+
+  group(MeApi, () {
+    //Future<Me> v1MeGet() async
+    test('test v1MeGet', () async {
+      // TODO
+    });
+
+    //Future<Me> v1MePatch(PatchMe patchMe) async
+    test('test v1MePatch', () async {
+      // TODO
+    });
+
+  });
+}

--- a/lib/core/api/generated/test/me_test.dart
+++ b/lib/core/api/generated/test/me_test.dart
@@ -1,0 +1,36 @@
+import 'package:test/test.dart';
+import 'package:fling_api/fling_api.dart';
+
+// tests for Me
+void main() {
+  final instance = MeBuilder();
+  // TODO add properties to the builder and call build()
+
+  group(Me, () {
+    // String uid
+    test('to test the property `uid`', () async {
+      // TODO
+    });
+
+    // String email
+    test('to test the property `email`', () async {
+      // TODO
+    });
+
+    // String displayName
+    test('to test the property `displayName`', () async {
+      // TODO
+    });
+
+    // BuiltList<String> householdIds
+    test('to test the property `householdIds`', () async {
+      // TODO
+    });
+
+    // String currentHouseholdId
+    test('to test the property `currentHouseholdId`', () async {
+      // TODO
+    });
+
+  });
+}

--- a/lib/core/api/generated/test/patch_me_test.dart
+++ b/lib/core/api/generated/test/patch_me_test.dart
@@ -1,0 +1,21 @@
+import 'package:test/test.dart';
+import 'package:fling_api/fling_api.dart';
+
+// tests for PatchMe
+void main() {
+  final instance = PatchMeBuilder();
+  // TODO add properties to the builder and call build()
+
+  group(PatchMe, () {
+    // String currentHouseholdId
+    test('to test the property `currentHouseholdId`', () async {
+      // TODO
+    });
+
+    // String displayName
+    test('to test the property `displayName`', () async {
+      // TODO
+    });
+
+  });
+}

--- a/lib/features/me/application/me_providers.dart
+++ b/lib/features/me/application/me_providers.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:fling/features/me/data/me_repository.dart';
+import 'package:fling/features/me/domain/me.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final firestoreProvider = Provider<FirebaseFirestore>((_) => FirebaseFirestore.instance);
+final firebaseAuthProvider = Provider<FirebaseAuth>((_) => FirebaseAuth.instance);
+
+final authStateProvider = StreamProvider<User?>((ref) {
+  return ref.watch(firebaseAuthProvider).authStateChanges();
+});
+
+final meRepositoryProvider = Provider<MeRepository>((ref) {
+  return MeRepository(firestore: ref.watch(firestoreProvider));
+});
+
+final meProvider = StreamProvider<Me?>((ref) {
+  final auth = ref.watch(authStateProvider).valueOrNull;
+  if (auth == null) return Stream.value(null);
+  return ref.watch(meRepositoryProvider).watch(auth.uid);
+});
+
+final currentHouseholdIdProvider = Provider<String?>((ref) {
+  return ref.watch(meProvider).valueOrNull?.currentHouseholdId;
+});
+
+final householdIdsProvider = Provider<List<String>>((ref) {
+  return ref.watch(meProvider).valueOrNull?.householdIds ?? const <String>[];
+});

--- a/lib/features/me/data/me_repository.dart
+++ b/lib/features/me/data/me_repository.dart
@@ -1,0 +1,16 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fling/features/me/domain/me.dart';
+
+class MeRepository {
+  MeRepository({required this.firestore});
+
+  final FirebaseFirestore firestore;
+
+  Stream<Me?> watch(String uid) {
+    return firestore.collection('users').doc(uid).snapshots().map((snap) {
+      final data = snap.data();
+      if (data == null) return null;
+      return Me.fromFirestoreDoc(uid, data);
+    });
+  }
+}

--- a/lib/features/me/domain/me.dart
+++ b/lib/features/me/domain/me.dart
@@ -1,0 +1,30 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'me.freezed.dart';
+part 'me.g.dart';
+
+@freezed
+class Me with _$Me {
+  const factory Me({
+    required String uid,
+    String? email,
+    String? displayName,
+    @Default(<String>[]) List<String> householdIds,
+    String? currentHouseholdId,
+  }) = _Me;
+
+  factory Me.fromJson(Map<String, dynamic> json) => _$MeFromJson(json);
+
+  factory Me.fromFirestoreDoc(String uid, Map<String, dynamic> data) {
+    return Me(
+      uid: uid,
+      email: data['email'] as String?,
+      displayName: data['display_name'] as String?,
+      householdIds: List<String>.from(
+        (data['household_ids'] ?? data['households'] ?? const <String>[]) as List,
+      ),
+      currentHouseholdId:
+          (data['current_household_id'] ?? data['current_household']) as String?,
+    );
+  }
+}

--- a/lib/features/me/domain/me.freezed.dart
+++ b/lib/features/me/domain/me.freezed.dart
@@ -1,0 +1,252 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'me.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Me _$MeFromJson(Map<String, dynamic> json) {
+  return _Me.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Me {
+  String get uid => throw _privateConstructorUsedError;
+  String? get email => throw _privateConstructorUsedError;
+  String? get displayName => throw _privateConstructorUsedError;
+  List<String> get householdIds => throw _privateConstructorUsedError;
+  String? get currentHouseholdId => throw _privateConstructorUsedError;
+
+  /// Serializes this Me to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Me
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $MeCopyWith<Me> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MeCopyWith<$Res> {
+  factory $MeCopyWith(Me value, $Res Function(Me) then) =
+      _$MeCopyWithImpl<$Res, Me>;
+  @useResult
+  $Res call(
+      {String uid,
+      String? email,
+      String? displayName,
+      List<String> householdIds,
+      String? currentHouseholdId});
+}
+
+/// @nodoc
+class _$MeCopyWithImpl<$Res, $Val extends Me> implements $MeCopyWith<$Res> {
+  _$MeCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Me
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? uid = null,
+    Object? email = freezed,
+    Object? displayName = freezed,
+    Object? householdIds = null,
+    Object? currentHouseholdId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      uid: null == uid
+          ? _value.uid
+          : uid // ignore: cast_nullable_to_non_nullable
+              as String,
+      email: freezed == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String?,
+      displayName: freezed == displayName
+          ? _value.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      householdIds: null == householdIds
+          ? _value.householdIds
+          : householdIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      currentHouseholdId: freezed == currentHouseholdId
+          ? _value.currentHouseholdId
+          : currentHouseholdId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MeImplCopyWith<$Res> implements $MeCopyWith<$Res> {
+  factory _$$MeImplCopyWith(_$MeImpl value, $Res Function(_$MeImpl) then) =
+      __$$MeImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String uid,
+      String? email,
+      String? displayName,
+      List<String> householdIds,
+      String? currentHouseholdId});
+}
+
+/// @nodoc
+class __$$MeImplCopyWithImpl<$Res> extends _$MeCopyWithImpl<$Res, _$MeImpl>
+    implements _$$MeImplCopyWith<$Res> {
+  __$$MeImplCopyWithImpl(_$MeImpl _value, $Res Function(_$MeImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Me
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? uid = null,
+    Object? email = freezed,
+    Object? displayName = freezed,
+    Object? householdIds = null,
+    Object? currentHouseholdId = freezed,
+  }) {
+    return _then(_$MeImpl(
+      uid: null == uid
+          ? _value.uid
+          : uid // ignore: cast_nullable_to_non_nullable
+              as String,
+      email: freezed == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String?,
+      displayName: freezed == displayName
+          ? _value.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      householdIds: null == householdIds
+          ? _value._householdIds
+          : householdIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      currentHouseholdId: freezed == currentHouseholdId
+          ? _value.currentHouseholdId
+          : currentHouseholdId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MeImpl implements _Me {
+  const _$MeImpl(
+      {required this.uid,
+      this.email,
+      this.displayName,
+      final List<String> householdIds = const <String>[],
+      this.currentHouseholdId})
+      : _householdIds = householdIds;
+
+  factory _$MeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MeImplFromJson(json);
+
+  @override
+  final String uid;
+  @override
+  final String? email;
+  @override
+  final String? displayName;
+  final List<String> _householdIds;
+  @override
+  @JsonKey()
+  List<String> get householdIds {
+    if (_householdIds is EqualUnmodifiableListView) return _householdIds;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_householdIds);
+  }
+
+  @override
+  final String? currentHouseholdId;
+
+  @override
+  String toString() {
+    return 'Me(uid: $uid, email: $email, displayName: $displayName, householdIds: $householdIds, currentHouseholdId: $currentHouseholdId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MeImpl &&
+            (identical(other.uid, uid) || other.uid == uid) &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.displayName, displayName) ||
+                other.displayName == displayName) &&
+            const DeepCollectionEquality()
+                .equals(other._householdIds, _householdIds) &&
+            (identical(other.currentHouseholdId, currentHouseholdId) ||
+                other.currentHouseholdId == currentHouseholdId));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, uid, email, displayName,
+      const DeepCollectionEquality().hash(_householdIds), currentHouseholdId);
+
+  /// Create a copy of Me
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MeImplCopyWith<_$MeImpl> get copyWith =>
+      __$$MeImplCopyWithImpl<_$MeImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MeImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Me implements Me {
+  const factory _Me(
+      {required final String uid,
+      final String? email,
+      final String? displayName,
+      final List<String> householdIds,
+      final String? currentHouseholdId}) = _$MeImpl;
+
+  factory _Me.fromJson(Map<String, dynamic> json) = _$MeImpl.fromJson;
+
+  @override
+  String get uid;
+  @override
+  String? get email;
+  @override
+  String? get displayName;
+  @override
+  List<String> get householdIds;
+  @override
+  String? get currentHouseholdId;
+
+  /// Create a copy of Me
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$MeImplCopyWith<_$MeImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/me/domain/me.g.dart
+++ b/lib/features/me/domain/me.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'me.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$MeImpl _$$MeImplFromJson(Map<String, dynamic> json) => _$MeImpl(
+      uid: json['uid'] as String,
+      email: json['email'] as String?,
+      displayName: json['displayName'] as String?,
+      householdIds: (json['householdIds'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const <String>[],
+      currentHouseholdId: json['currentHouseholdId'] as String?,
+    );
+
+Map<String, dynamic> _$$MeImplToJson(_$MeImpl instance) => <String, dynamic>{
+      'uid': instance.uid,
+      'email': instance.email,
+      'displayName': instance.displayName,
+      'householdIds': instance.householdIds,
+      'currentHouseholdId': instance.currentHouseholdId,
+    };

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
 import 'package:provider/provider.dart';
 import 'firebase_options.dart';
 
@@ -30,12 +31,19 @@ Future<void> main() async {
 
   Stream<FlingUser?> user = FlingUser.currentUser;
 
-  runApp(MultiProvider(providers: [
-    StreamProvider<FlingUser?>(
-      create: (context) => user,
-      initialData: null,
-    )
-  ], child: const FlingApp()));
+  runApp(
+    ProviderScope(
+      child: MultiProvider(
+        providers: [
+          StreamProvider<FlingUser?>(
+            create: (context) => user,
+            initialData: null,
+          ),
+        ],
+        child: const FlingApp(),
+      ),
+    ),
+  );
 }
 
 class FlingApp extends StatelessWidget {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -23,6 +23,56 @@
           "status",
           "version"
         ]
+      },
+      "Me": {
+        "type": "object",
+        "properties": {
+          "uid": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "nullable": true,
+            "format": "email"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "householdIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "currentHouseholdId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "uid",
+          "email",
+          "displayName",
+          "householdIds",
+          "currentHouseholdId"
+        ]
+      },
+      "PatchMe": {
+        "type": "object",
+        "properties": {
+          "currentHouseholdId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "displayName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "additionalProperties": false
       }
     },
     "parameters": {}
@@ -37,6 +87,52 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Health"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/me": {
+      "get": {
+        "tags": [
+          "me"
+        ],
+        "responses": {
+          "200": {
+            "description": "The caller",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Me"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "me"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchMe"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Me"
                 }
               }
             }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -58,6 +58,32 @@
           "currentHouseholdId"
         ]
       },
+      "ApiError": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {
+                "nullable": true
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
       "PatchMe": {
         "type": "object",
         "properties": {
@@ -109,6 +135,26 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User document not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
           }
         }
       },
@@ -133,6 +179,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Me"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.35"
+  adaptive_number:
+    dependency: transitive
+    description:
+      name: adaptive_number
+      sha256: "3a567544e9b5c9c803006f51140ad544aedc79604fd4f3f2c1380003f97c1d77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   analyzer:
     dependency: transitive
     description:
@@ -33,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.0"
+  antlr4:
+    dependency: transitive
+    description:
+      name: antlr4
+      sha256: "752b4a6e4ad97953652a2b2bbf5377f46c94b579d3372b50080c7e5858234a05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.2"
   archive:
     dependency: transitive
     description:
@@ -137,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.10.1"
+  cel:
+    dependency: transitive
+    description:
+      name: cel
+      sha256: "51d77e16424d41b5fdb0a239be4c8a0550d4dd3f952801d35375ddd90cfb49da"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4+1"
   characters:
     dependency: transitive
     description:
@@ -313,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0+7.7.0"
+  dart_jsonwebtoken:
+    dependency: transitive
+    description:
+      name: dart_jsonwebtoken
+      sha256: "00a0812d2aeaeb0d30bcbc4dd3cee57971dbc0ab2216adf4f0247f37793f15ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.17.0"
   dart_style:
     dependency: transitive
     description:
@@ -361,6 +393,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.1"
+  ed25519_edwards:
+    dependency: transitive
+    description:
+      name: ed25519_edwards
+      sha256: "6ce0112d131327ec6d42beede1e5dfd526069b18ad45dcf654f15074ad9276cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   email_validator:
     dependency: transitive
     description:
@@ -369,6 +409,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.17"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -377,6 +425,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  fake_cloud_firestore:
+    dependency: "direct dev"
+    description:
+      name: fake_cloud_firestore
+      sha256: "1524e1dd4ed091c62c725bc8d30ad8b47d326841965be26904f9eaffa2f81360"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.2"
+  fake_firebase_security_rules:
+    dependency: transitive
+    description:
+      name: fake_firebase_security_rules
+      sha256: "6af54bedfd6985451a9735f2cfac91ffe0128bfc92bf15e8544cd56c6941d6cc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4"
   ffi:
     dependency: transitive
     description:
@@ -401,6 +465,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.20.0"
+  firebase_auth_mocks:
+    dependency: "direct dev"
+    description:
+      name: firebase_auth_mocks
+      sha256: "1d04d1c14d1ead8be29b255f945a8448e11abcb8dda4cc143e5af9e3583f253a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.0"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
@@ -725,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   logging:
     dependency: transitive
     description:
@@ -765,6 +845,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mock_exceptions:
+    dependency: transitive
+    description:
+      name: mock_exceptions
+      sha256: "6e3e623712d2c6106ffe9e14732912522b565ddaa82a8dcee6cd4441b5984056"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.2"
+  more:
+    dependency: transitive
+    description:
+      name: more
+      sha256: e252628d2183cc09539b686abfbd9d8302675959b89a2a8146f5f4baca6ac5ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.0"
   nested:
     dependency: transitive
     description:
@@ -885,6 +981,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:
@@ -957,8 +1061,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.4"
-  rxdart:
+  rx:
     dependency: transitive
+    description:
+      name: rx
+      sha256: "7f54bd39cc63a01c770c1de4b6ce8e135eb13119614cba2216bd9a93ccd29e56"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
+  rxdart:
+    dependency: "direct overridden"
     description:
       name: rxdart
       sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,6 +76,11 @@ dev_dependencies:
   freezed: ^2.5.7
   json_serializable: ^6.8.0
   riverpod_lint: ^2.6.1
+  fake_cloud_firestore: ^2.5.2
+  firebase_auth_mocks: ^0.13.0
+
+dependency_overrides:
+  rxdart: ^0.28.0
 
 flutter_icons:
   android: "launcher_icon"

--- a/test/features/me/me_providers_test.dart
+++ b/test/features/me/me_providers_test.dart
@@ -1,0 +1,34 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:fling/features/me/application/me_providers.dart';
+import 'package:fling/features/me/domain/me.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test("meProvider streams the current auth user's doc", () async {
+    final firestore = FakeFirebaseFirestore();
+    final mockUser = MockUser(uid: 'alice', email: 'alice@example.com');
+    final auth = MockFirebaseAuth(signedIn: true, mockUser: mockUser);
+    await firestore.collection('users').doc('alice').set({
+      'email': 'alice@example.com',
+      'household_ids': ['h1'],
+      'current_household_id': 'h1',
+    });
+
+    final container = ProviderContainer(overrides: [
+      firestoreProvider.overrideWithValue(firestore),
+      firebaseAuthProvider.overrideWithValue(auth),
+    ]);
+    addTearDown(container.dispose);
+
+    // A listener is required to keep the provider reactive to dependency changes.
+    final sub = container.listen(meProvider, (_, __) {}, fireImmediately: true);
+    addTearDown(sub.close);
+
+    final me = await container.read(meProvider.future);
+    expect(me, isA<Me>());
+    expect(me!.uid, 'alice');
+    expect(me.currentHouseholdId, 'h1');
+  });
+}

--- a/test/features/me/me_repository_test.dart
+++ b/test/features/me/me_repository_test.dart
@@ -1,0 +1,47 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:fling/features/me/data/me_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MeRepository.watch', () {
+    test('emits Me with new field names when present', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('alice').set({
+        'email': 'alice@example.com',
+        'display_name': 'Alice',
+        'household_ids': ['h1', 'h2'],
+        'current_household_id': 'h1',
+        'schema_version': 1,
+      });
+      final repo = MeRepository(firestore: firestore);
+      final me = await repo.watch('alice').first;
+      expect(me, isNotNull);
+      expect(me!.uid, 'alice');
+      expect(me.email, 'alice@example.com');
+      expect(me.displayName, 'Alice');
+      expect(me.householdIds, ['h1', 'h2']);
+      expect(me.currentHouseholdId, 'h1');
+    });
+
+    test('falls back to legacy field names', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('alice').set({
+        'households': ['h1'],
+        'current_household': 'h1',
+      });
+      final repo = MeRepository(firestore: firestore);
+      final me = await repo.watch('alice').first;
+      expect(me!.householdIds, ['h1']);
+      expect(me.currentHouseholdId, 'h1');
+      expect(me.displayName, isNull);
+      expect(me.email, isNull);
+    });
+
+    test('emits null when the doc does not exist', () async {
+      final firestore = FakeFirebaseFirestore();
+      final repo = MeRepository(firestore: firestore);
+      final me = await repo.watch('ghost').first;
+      expect(me, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First slice of Phase 1 (`me` slice + API foundation). No user-visible change — `FlingUser` and all legacy code stays alive in parallel.

**Backend:**
- `core/middleware`: `requestId`, `auth` (Firebase ID token), `AppError` hierarchy + Hono `onError` handler
- `core/context`: `RequestContext` (`{ uid, email, requestId, householdId? }`) threaded through services
- `core/logger`: structured JSON logger with `withRequestContext` binding
- `features/me`: schemas (`Me`, `PatchMe`), repo (dual-write `current_household`/`current_household_id`, legacy-field fallback), service (`getMe`, `patchMe`, `createUser`, `deleteUser`), `GET /v1/me` + `PATCH /v1/me` routes with `401`/`404` documented in OpenAPI
- `firebase.json`: `singleProjectMode: false` (required for multi-project-ID emulator tests)

**Flutter:**
- `ProviderScope` wraps the app root (existing `MultiProvider`/`FlingUser` untouched inside)
- `features/me/domain/Me` — freezed model with `fromFirestoreDoc` factory (new + legacy field fallback)
- `features/me/data/MeRepository` — Firestore stream → `Me?`
- `features/me/application` — 7 Riverpod providers: `firestoreProvider`, `firebaseAuthProvider`, `authStateProvider`, `meRepositoryProvider`, `meProvider`, `currentHouseholdIdProvider`, `householdIdsProvider`

**OpenAPI + Dart client** regenerated; `Me` + `PatchMe` schemas live in `lib/core/api/generated/`.

## Test plan
- [ ] CI green (backend, flutter, contracts)
- [ ] After merge + deploy: `curl -H "Authorization: Bearer <token>" https://us-central1-fling-list.cloudfunctions.net/api/v1/me` returns the user doc
- [ ] Flutter prod app still works exactly as before (login, view lists, switch household, apply template — all legacy paths untouched)

Made with [Cursor](https://cursor.com)