### PR TITLE
fix(mutation-queue): fire-and-forget contract; surface failures via stream

### DIFF
--- a/docs/superpowers/specs/2026-04-24-fling-rewrite-design.md
+++ b/docs/superpowers/specs/2026-04-24-fling-rewrite-design.md
@@ -466,6 +466,17 @@ pending mutations. Each action:
 This is encapsulated in `core/api/mutation_queue.dart` and reused by every
 feature.
 
+**`MutationQueue.enqueue` is fire-and-forget.** It returns once the
+mutation is durably persisted to the local queue, *not* when the server
+has confirmed (steps 3 + 4 happen in the background). Call sites must not
+`await` it as if it were a synchronous network call — doing so re-introduces
+round-trip latency on whatever modal/page is awaiting and defeats the
+overlay (the screen behind updates, but the user is staring at the
+modal). Pop dialogs / pages / dismiss spinners synchronously after
+`enqueue` resolves; failures arrive on `MutationQueue.failures` and are
+surfaced by a top-level listener (step 5). See
+[#563](https://github.com/garritfra/fling/issues/563).
+
 ### 7.6 Offline writes
 
 The mutation queue persists to disk. On app start and on `connectivity_plus`

--- a/lib/core/api/mutation_failure_listener.dart
+++ b/lib/core/api/mutation_failure_listener.dart
@@ -1,0 +1,34 @@
+import 'package:fling/core/api/mutation_queue.dart';
+import 'package:fling/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Subscribes to `mutationFailuresProvider` and shows a `SnackBar` via the
+/// nearest `ScaffoldMessenger` for every terminal mutation failure.
+///
+/// Mounted once near the app root so the design spec §7.5 step 5
+/// ("on failure: surface a FlingErrorSnackBar") has somewhere to land —
+/// without forcing every call site to wrap `enqueue` in a try/catch.
+class MutationFailureListener extends ConsumerWidget {
+  const MutationFailureListener({super.key, required this.child});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue<MutationFailure>>(
+      mutationFailuresProvider,
+      (_, next) => next.whenData((f) => _show(context, f)),
+    );
+    return child;
+  }
+
+  void _show(BuildContext context, MutationFailure f) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    final l10n = AppLocalizations.of(context);
+    final headline = l10n?.status_error ?? 'Something went wrong.';
+    messenger.showSnackBar(SnackBar(
+      content: Text('$headline (${f.error.code})'),
+    ));
+  }
+}

--- a/lib/core/api/mutation_queue.dart
+++ b/lib/core/api/mutation_queue.dart
@@ -9,7 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 export 'package:fling/core/api/failures.dart' show ApiFailure, NetworkFailure;
 
-class MutationSpec<T> {
+class MutationSpec {
   MutationSpec({
     required this.type,
     required this.resourceKey,
@@ -21,7 +21,7 @@ class MutationSpec<T> {
   final String resourceKey;
   final Map<String, Object?> body;
   final String? idempotencyKey;
-  final Future<T> Function(String idempotencyKey) call;
+  final Future<void> Function(String idempotencyKey) call;
 }
 
 class PendingMutation {
@@ -59,9 +59,31 @@ class PendingMutation {
       );
 }
 
+/// A mutation that the server rejected terminally (4xx non-409). Surfaced
+/// on [MutationQueue.failures] so a top-level listener can show a
+/// `FlingErrorSnackBar`. Matches the design spec §7.5 step 5.
+class MutationFailure {
+  const MutationFailure({required this.mutation, required this.error});
+  final PendingMutation mutation;
+  final ApiFailure error;
+}
+
 abstract class MutationQueue {
-  Future<T> enqueue<T>(MutationSpec<T> spec);
+  /// Enqueue a mutation. Resolves once the mutation is **durably persisted
+  /// to the local queue** — *not* when the server has confirmed. The HTTP
+  /// call runs in the background; terminal failures arrive on [failures].
+  ///
+  /// Call sites must not `await` for the round-trip via this future. The
+  /// optimistic overlay (see [overlay]) is what makes the new state visible
+  /// to the UI immediately; pop dialogs / pages synchronously after this
+  /// resolves.
+  Future<void> enqueue(MutationSpec spec);
+
   Stream<List<PendingMutation>> get pending;
+
+  /// Terminal failures (4xx non-409). Subscribers translate to UI
+  /// (top-level `FlingErrorSnackBar`).
+  Stream<MutationFailure> get failures;
 
   /// Apply pending mutations on top of an upstream snapshot. Resource-keyed.
   T overlay<T>(
@@ -85,10 +107,11 @@ class MutationQueueImpl implements MutationQueue {
   final SharedPreferences prefs;
   final Stream<bool> _online;
   late final StreamSubscription<bool> _onlineSub;
-  final _controller = StreamController<List<PendingMutation>>.broadcast();
+  final _pendingController =
+      StreamController<List<PendingMutation>>.broadcast();
+  final _failureController = StreamController<MutationFailure>.broadcast();
   final List<PendingMutation> _queue = [];
-  final Map<String, Completer<dynamic>> _completers = {};
-  final Map<String, Future<dynamic> Function(String)> _calls = {};
+  final Map<String, Future<void> Function(String)> _calls = {};
 
   void _load() {
     final raw = prefs.getString(_prefsKey);
@@ -106,17 +129,20 @@ class MutationQueueImpl implements MutationQueue {
   }
 
   void _emit() {
-    _controller.add(List.unmodifiable(_queue));
+    _pendingController.add(List.unmodifiable(_queue));
   }
 
   @override
   Stream<List<PendingMutation>> get pending {
     Future<void>.microtask(_emit);
-    return _controller.stream;
+    return _pendingController.stream;
   }
 
   @override
-  Future<T> enqueue<T>(MutationSpec<T> spec) async {
+  Stream<MutationFailure> get failures => _failureController.stream;
+
+  @override
+  Future<void> enqueue(MutationSpec spec) async {
     final key = spec.idempotencyKey ?? newIdempotencyKey();
     final p = PendingMutation(
       idempotencyKey: key,
@@ -126,37 +152,33 @@ class MutationQueueImpl implements MutationQueue {
       createdAt: DateTime.now().toUtc(),
     );
     _queue.add(p);
-    final completer = Completer<T>();
-    _completers[key] = completer;
     _calls[key] = spec.call;
     await _persist();
     _emit();
+    // Run the network call in the background. The caller is unblocked the
+    // moment the mutation is in the queue + persisted; the overlay makes
+    // the new state visible immediately.
     unawaited(_runOne(p));
-    return completer.future;
   }
 
   Future<void> _runOne(PendingMutation p) async {
     final call = _calls[p.idempotencyKey];
-    final completer = _completers[p.idempotencyKey];
-    if (call == null || completer == null) return;
+    if (call == null) return;
     p.attempts++;
     try {
-      final result = await call(p.idempotencyKey);
+      await call(p.idempotencyKey);
       _queue.removeWhere((q) => q.idempotencyKey == p.idempotencyKey);
-      _completers.remove(p.idempotencyKey);
       _calls.remove(p.idempotencyKey);
-      completer.complete(result);
     } on NetworkFailure {
       // Stay pending; retried on next drain / connectivity event.
     } on ApiFailure catch (e) {
-      // 409 is a server-side conflict — keep it pending so the caller can
-      // resolve it (e.g. fresh idempotency key). All other 4xx are caller
-      // errors; drop and rethrow so the caller sees them.
+      // 409 is a server-side conflict — keep it pending so a future drain
+      // (e.g. fresh idempotency key) can resolve it. All other 4xx are
+      // terminal: drop the mutation and surface on `failures`.
       if (e.status >= 400 && e.status < 500 && e.status != 409) {
         _queue.removeWhere((q) => q.idempotencyKey == p.idempotencyKey);
-        _completers.remove(p.idempotencyKey);
         _calls.remove(p.idempotencyKey);
-        completer.completeError(e);
+        _failureController.add(MutationFailure(mutation: p, error: e));
       }
     } catch (_) {
       // Unknown error — treat as transient.
@@ -189,7 +211,8 @@ class MutationQueueImpl implements MutationQueue {
 
   Future<void> dispose() async {
     await _onlineSub.cancel();
-    await _controller.close();
+    await _pendingController.close();
+    await _failureController.close();
   }
 }
 
@@ -212,4 +235,12 @@ final mutationQueueProvider = FutureProvider<MutationQueue>((ref) async {
   final queue = MutationQueueImpl(prefs: prefs, online: online);
   ref.onDispose(queue.dispose);
   return queue;
+});
+
+/// Surface for terminal mutation failures. Exposed as a StreamProvider so
+/// listeners (e.g. the top-level snackbar) can use `ref.listen` rather
+/// than tracking a `StreamSubscription` themselves.
+final mutationFailuresProvider = StreamProvider<MutationFailure>((ref) async* {
+  final queue = await ref.watch(mutationQueueProvider.future);
+  yield* queue.failures;
 });

--- a/lib/features/me/data/me_repository.dart
+++ b/lib/features/me/data/me_repository.dart
@@ -58,7 +58,7 @@ class MeRepository {
       if (currentHouseholdId != null) 'currentHouseholdId': currentHouseholdId,
       if (displayName != null) 'displayName': displayName,
     };
-    await mutations.enqueue(MutationSpec<void>(
+    await mutations.enqueue(MutationSpec(
       type: MeMutations.patchType,
       resourceKey: MeMutations.resourceKey(uid),
       body: body,

--- a/lib/features/me/presentation/household_switcher_dialog.dart
+++ b/lib/features/me/presentation/household_switcher_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fling/data/household.dart';
 import 'package:fling/features/me/application/me_providers.dart';
 import 'package:fling/l10n/app_localizations.dart';
@@ -31,11 +33,14 @@ Future<void> showHouseholdSwitcherDialog(
                   shrinkWrap: true,
                   children: [
                     ...households.map((h) => ListTile(
-                          onTap: () async {
-                            await ref
+                          onTap: () {
+                            // Fire-and-forget: the mutation queue persists +
+                            // applies the optimistic overlay synchronously
+                            // (#563); awaiting here would re-introduce
+                            // round-trip latency on the dialog.
+                            unawaited(ref
                                 .read(meControllerProvider)
-                                .setCurrentHousehold(h.id!);
-                            if (!ctx.mounted) return;
+                                .setCurrentHousehold(h.id!));
                             Navigator.pop(ctx);
                           },
                           title: Text(h.name),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:fling/pages/login.dart';
 import 'package:fling/pages/template.dart';
 import 'package:fling/pages/templates.dart';
 import 'package:flutter/foundation.dart' show kDebugMode, kIsWeb;
+import 'package:fling/core/api/mutation_failure_listener.dart';
 import 'package:fling/core/firebase/emulators.dart';
 import 'package:fling/pages/list.dart';
 import 'package:fling/pages/lists.dart';
@@ -60,6 +61,9 @@ class FlingApp extends StatelessWidget {
         darkTheme: ThemeData(
             useMaterial3: true,
             colorScheme: darkDynamic ?? ThemeData.dark().colorScheme),
+        // Top-level surface for terminal mutation failures (spec §7.5 step 5).
+        builder: (context, child) =>
+            MutationFailureListener(child: child ?? const SizedBox.shrink()),
         initialRoute:
             fba.FirebaseAuth.instance.currentUser == null ? '/login' : '/',
         routes: <String, WidgetBuilder>{

--- a/lib/pages/household_add.dart
+++ b/lib/pages/household_add.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fling/data/household.dart';
 import 'package:fling/features/me/application/me_providers.dart';
 import 'package:fling/l10n/app_localizations.dart';
@@ -18,12 +20,15 @@ class _AddHouseholdState extends ConsumerState<AddHousehold> {
     final nameController = TextEditingController();
 
     Future<void> onCreateHousehold() async {
+      // The household-doc create is still synchronous because we need the
+      // server-assigned id back. Switching the active household goes
+      // through the mutation queue, which persists + overlays optimistically
+      // (#563); fire-and-forget so the page dismisses without waiting on
+      // PATCH /v1/me.
       final household = await HouseholdModel(name: nameController.text).save();
-      // Switch the current household via the new API + mutation queue
-      // (PATCH /v1/me).
-      await ref
+      unawaited(ref
           .read(meControllerProvider)
-          .setCurrentHousehold(household.id!);
+          .setCurrentHousehold(household.id!));
 
       if (!context.mounted) return;
       Navigator.pop(context);

--- a/test/_helpers/noop_dependencies.dart
+++ b/test/_helpers/noop_dependencies.dart
@@ -15,10 +15,13 @@ class NoopFlingApi implements FlingApi {
 /// mutations" — useful when a repo test cares about read paths only.
 class NoopMutationQueue implements MutationQueue {
   @override
-  Future<T> enqueue<T>(MutationSpec<T> spec) => spec.call('test');
+  Future<void> enqueue(MutationSpec spec) => spec.call('test');
 
   @override
   Stream<List<PendingMutation>> get pending => const Stream.empty();
+
+  @override
+  Stream<MutationFailure> get failures => const Stream.empty();
 
   @override
   T overlay<T>(

--- a/test/core/api/mutation_queue_test.dart
+++ b/test/core/api/mutation_queue_test.dart
@@ -14,24 +14,54 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  test('enqueue runs the call once on success and removes from pending',
+  test('enqueue resolves before the call is invoked (fire-and-forget)',
       () async {
+    // Regression test for https://github.com/garritfra/fling/issues/563:
+    // `enqueue` must return as soon as the mutation is durably persisted,
+    // not when the server has confirmed. Otherwise call sites awaiting it
+    // block on the round-trip and the optimistic overlay never gets seen.
+    final prefs = await SharedPreferences.getInstance();
+    final connectivity = _Connectivity();
+    final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
+    final callStarted = Completer<void>();
+    final letCallFinish = Completer<void>();
+    final enqueueDone = Completer<void>();
+
+    unawaited(q.enqueue(MutationSpec(
+      type: 'me.patch',
+      resourceKey: 'me/alice',
+      body: const {'displayName': 'Alice'},
+      call: (key) async {
+        callStarted.complete();
+        await letCallFinish.future;
+      },
+    )).then((_) => enqueueDone.complete()));
+
+    // `enqueue`'s future must resolve without the call having to finish.
+    await enqueueDone.future;
+    expect(callStarted.isCompleted, isTrue,
+        reason: 'call should have started in the background');
+    expect(letCallFinish.isCompleted, isFalse,
+        reason: 'enqueue should not wait for the call to finish');
+    letCallFinish.complete();
+  });
+
+  test('successful enqueue runs the call and clears pending', () async {
     final prefs = await SharedPreferences.getInstance();
     final connectivity = _Connectivity();
     final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
     var calls = 0;
-    final result = await q.enqueue(MutationSpec<int>(
+    await q.enqueue(MutationSpec(
       type: 'me.patch',
       resourceKey: 'me/alice',
       body: const {'displayName': 'Alice'},
       call: (key) async {
         calls++;
-        return 1;
       },
     ));
-    expect(result, 1);
+    // The call runs in the background; wait for the queue to settle.
+    await q.pending.firstWhere((l) => l.isEmpty);
     expect(calls, 1);
-    expect(await q.pending.first, isEmpty);
   });
 
   test('on transient failure the mutation stays pending until drain succeeds',
@@ -40,42 +70,43 @@ void main() {
     final connectivity = _Connectivity();
     final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
     var attempts = 0;
-    final f = q.enqueue(MutationSpec<int>(
+    await q.enqueue(MutationSpec(
       type: 'me.patch',
       resourceKey: 'me/alice',
       body: const {'displayName': 'Alice'},
       call: (key) async {
         attempts++;
         if (attempts < 2) throw const NetworkFailure();
-        return 1;
       },
     ));
+    // First attempt fails with NetworkFailure; mutation stays pending.
     await Future<void>.delayed(const Duration(milliseconds: 30));
     expect((await q.pending.first).length, 1);
+    // Connectivity event triggers a drain; second attempt succeeds.
     connectivity.controller.add(true);
-    expect(await f, 1);
+    await q.pending.firstWhere((l) => l.isEmpty);
     expect(attempts, 2);
-    expect(await q.pending.first, isEmpty);
   });
 
-  test('on permanent failure (4xx non-409) the mutation is dropped and rethrown',
-      () async {
+  test(
+      'on permanent failure (4xx non-409) the mutation is dropped and surfaced'
+      ' on `failures`', () async {
     final prefs = await SharedPreferences.getInstance();
     final connectivity = _Connectivity();
     final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
-    Object? caught;
-    try {
-      await q.enqueue(MutationSpec<int>(
-        type: 'me.patch',
-        resourceKey: 'me/alice',
-        body: const {'displayName': ''},
-        call: (key) async =>
-            throw const ApiFailure(400, 'BAD_REQUEST', 'too short'),
-      ));
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught, isA<ApiFailure>());
+    final failureFuture = q.failures.first;
+    await q.enqueue(MutationSpec(
+      type: 'me.patch',
+      resourceKey: 'me/alice',
+      body: const {'displayName': ''},
+      call: (key) async =>
+          throw const ApiFailure(400, 'BAD_REQUEST', 'too short'),
+    ));
+    final failure = await failureFuture;
+    expect(failure.error.status, 400);
+    expect(failure.error.code, 'BAD_REQUEST');
+    expect(failure.mutation.type, 'me.patch');
+    expect(failure.mutation.resourceKey, 'me/alice');
     expect(await q.pending.first, isEmpty);
   });
 
@@ -84,17 +115,14 @@ void main() {
     var prefs = await SharedPreferences.getInstance();
     final connectivity1 = _Connectivity();
     final q1 = MutationQueueImpl(prefs: prefs, online: connectivity1.stream);
-    // Enqueue without awaiting; force a transient failure by never going online.
-    final completer = Completer<int>();
-    unawaited(q1.enqueue(MutationSpec<int>(
+    // Enqueue a mutation that will keep failing (offline) so it stays
+    // pending across queue instances.
+    await q1.enqueue(MutationSpec(
       type: 'me.patch',
       resourceKey: 'me/alice',
       body: const {'displayName': 'A'},
-      call: (key) async {
-        if (!completer.isCompleted) throw const NetworkFailure();
-        return 1;
-      },
-    )).then(completer.complete, onError: (_) {}));
+      call: (key) async => throw const NetworkFailure(),
+    ));
     await Future<void>.delayed(const Duration(milliseconds: 30));
     expect((await q1.pending.first).length, 1);
 
@@ -109,17 +137,17 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     final connectivity = _Connectivity();
     final q = MutationQueueImpl(prefs: prefs, online: connectivity.stream);
-    final completer = Completer<int>();
-    unawaited(q.enqueue(MutationSpec<int>(
+    final letCallFinish = Completer<void>();
+    await q.enqueue(MutationSpec(
       type: 'me.patch',
       resourceKey: 'me/alice',
       body: const {'displayName': 'Optimistic'},
       call: (key) async {
-        await completer.future;
-        return 1;
+        await letCallFinish.future;
       },
-    )));
-    await Future<void>.delayed(const Duration(milliseconds: 10));
+    ));
+    // While the call is in flight the mutation is in the queue and the
+    // overlay applies.
     final base = {'displayName': 'Old'};
     final overlaid = q.overlay<Map<String, Object?>>(
       base,
@@ -127,6 +155,6 @@ void main() {
       resourceKey: 'me/alice',
     );
     expect(overlaid['displayName'], 'Optimistic');
-    completer.complete(1);
+    letCallFinish.complete();
   });
 }


### PR DESCRIPTION
## Summary

- `MutationQueue.enqueue` is now fire-and-forget: it resolves once the mutation is durably persisted to the local queue, not when the server has confirmed. The HTTP call runs in the background.
- Terminal failures (4xx non-409) flow on a new `Stream<MutationFailure> failures` getter; a top-level `MutationFailureListener` consumes it and shows a `SnackBar`.
- Spec §7.5 updated with explicit fire-and-forget wording so the next migrator doesn't reintroduce an `await`.

Closes #563.

## Why a contract fix, not per-call-site `unawaited(...)`

The investigation in #563 showed that the latency wasn't household-specific — it was the queue's contract. Every endpoint migrated to this queue inherits the same problem: the type signature `Future<T> enqueue<T>(MutationSpec<T>)` invites `await`, which blocks the caller on the full round-trip. Phase 2 (households + members + invites), Phase 3 (lists), and Phase 4 (templates) all land here. Without a contract fix, every migrator would re-introduce the bug at every new call site.

The new signature `Future<void> enqueue(MutationSpec spec)` resolves after `_persist()` (microseconds) and runs the HTTP call via `unawaited(_runOne(p))`. The optimistic overlay is what makes the new state visible to the UI immediately — it was already correct, but the await chain was hiding it.

## Test plan

- [x] New regression test: `enqueue resolves before the call is invoked (fire-and-forget)` — locks the contract.
- [x] Existing queue tests rewritten to the new contract (success, transient failure, permanent failure surfaced on `failures`, persistence, overlay).
- [x] `flutter test`: all 14 tests pass.
- [x] `flutter analyze` on touched files: no issues.
- [ ] Manual: switch household via the switcher dialog — dialog dismisses immediately; home shows new household via overlay; HTTP completes in background.
- [ ] Manual: create new household — page dismisses after the household-doc create round-trip (still required client-side; needs a backend route to fix, see "Out of scope" below).
- [ ] Manual: induce a 4xx failure on PATCH /v1/me (e.g. emulator with rules denial) — verify snackbar appears.

## What this does NOT solve

- **Three serial round-trips inside `HouseholdModel.save()`** (households.add → members.set → PATCH /v1/me). Pre-dates the queue and isn't routed through it. Needs a `POST /v1/households` server route — Phase 2 work, matches #563's original suggestion.
- **Brief stale-display flicker on switch** (`currentHouseholdProvider` re-creates its stream on id change; Riverpod 2.6 preserves previous via `AsyncLoading.copyWithPrevious`, so it's a stale-old-name flash, not blank). Cosmetic.
- **Pre-existing bug, separate follow-up:** `MutationQueueImpl` persists `_queue` to disk but `_calls` is in-memory only — persisted pending mutations are orphaned on cold start. The proper fix is dispatch-by-`type` rather than per-mutation closures. Worth filing separately when Phase 2 lands more mutation types.

## Files

- `lib/core/api/mutation_queue.dart` — contract change, `failures` stream, `mutationFailuresProvider`.
- `lib/core/api/mutation_failure_listener.dart` — new top-level listener (`ConsumerWidget` + `ref.listen`).
- `lib/main.dart` — mounts the listener via `MaterialApp.builder`.
- `lib/features/me/data/me_repository.dart` — `MutationSpec<void>` → `MutationSpec` (vestigial type param).
- `lib/features/me/presentation/household_switcher_dialog.dart` — pop synchronously.
- `lib/pages/household_add.dart` — pop synchronously after `save()`.
- `docs/superpowers/specs/2026-04-24-fling-rewrite-design.md` §7.5 — explicit fire-and-forget contract.
- `test/core/api/mutation_queue_test.dart` — regression test + existing tests rewritten.
- `test/_helpers/noop_dependencies.dart` — `NoopMutationQueue` updated to new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)